### PR TITLE
Optimize Property rendering

### DIFF
--- a/app/bank/Bank.js
+++ b/app/bank/Bank.js
@@ -10,17 +10,23 @@ import {
   PropertyList
 } from '../properties'
 
-export default class extends Component {
+export default class Bank extends Component {
+  state = {
+    activeProperty: 0
+  }
 
   render() {
     let { properties } = this.props
+    let { activeProperty } = this.state
 
     return (
       <Container>
         <PropertyList
           style={styles.propertyList}
+          onUpdate={(i) => this.setState({ activeProperty: i })}
+          index={activeProperty}
           properties={properties}
-          start={0}
+          cardsToShow={5}
           offset={40}
         />
       </Container>

--- a/app/player/Player.js
+++ b/app/player/Player.js
@@ -94,19 +94,18 @@ export default class Player extends Component {
 
         {listView ? (
           <PropertyList
-            style={styles.propertyList}
+            onUpdate={(i) => this.setState({ activeProperty: i })}
+            index={activeProperty}
             properties={properties}
-            start={activeProperty}
             offset={headerHeight}
+            cardsToShow={3}
           />
         ) : (
           <View style={{ flex: 1 }}>
-            <Content>
-              <PropertyGrid
-                properties={properties}
-                onGroupPress={this.goToListView}
-              />
-            </Content>
+            <PropertyGrid
+              properties={properties}
+              onGroupPress={this.goToListView}
+            />
 
             {this.renderFooter()}
           </View>
@@ -128,12 +127,5 @@ const styles = StyleSheet.create({
     fontFamily: 'futura',
     color: 'rgb(100,200,100)',
     alignItems: 'center'
-  },
-  propertyList: {
-    position: 'absolute',
-    height: '100%',
-    width: '100%',
-    top: 0,
-    left: 0
   }
 })

--- a/app/properties/PropertyGrid.js
+++ b/app/properties/PropertyGrid.js
@@ -1,44 +1,20 @@
 import React, { Component } from 'react'
-import { View, TouchableOpacity, StyleSheet } from 'react-native'
+import { View, TouchableOpacity, Dimensions, StyleSheet } from 'react-native'
 
 import { PropertyGroup } from './components'
 
 export default class PropertyGrid extends Component {
-  state = {
-    groupStyle: {}
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      groups: this.groupProperties(props.properties)
+    }
   }
 
-  render() {
-    let { properties, onGroupPress } = this.props
-    let { groupStyle } = this.state
-
-    let groups = this.groupProperties(properties)
-
-    return (
-      <View
-          style={styles.container}
-          onLayout={this._updateStyles}>
-        {groups.map((properties, i) => (
-          <TouchableOpacity key={i}
-              style={[styles.group, groupStyle]}
-              onPress={() => onGroupPress(properties[0]._id)}>
-            <View>
-              <PropertyGroup
-                properties={properties}
-                simple
-              />
-            </View>
-          </TouchableOpacity>
-        ))}
-      </View>
-    )
-  }
-
-  _updateStyles = ({ nativeEvent: { layout: { width } } }) => {
+  componentWillReceiveProps({ properties }) {
     this.setState({
-      groupStyle: {
-        width: (width / 4) - 30
-      }
+      groups: this.groupProperties(properties)
     })
   }
 
@@ -57,14 +33,38 @@ export default class PropertyGrid extends Component {
 
     return groups.map((g) => grouped[g])
   }
+
+  render() {
+    let { onGroupPress } = this.props
+    let groupWidth = ((Dimensions.get('window').width - 30) / 4) - 30
+
+    return (
+      <View style={styles.container}>
+        {this.state.groups.map((properties, i) => (
+          <TouchableOpacity key={i}
+              style={styles.group}
+              onPress={() => onGroupPress(properties[0]._id)}>
+            <View>
+              <PropertyGroup
+                width={groupWidth}
+                properties={properties}
+                simple
+              />
+            </View>
+          </TouchableOpacity>
+        ))}
+      </View>
+    )
+  }
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginRight: -15,
-    marginLeft: -15
+    paddingRight: 15,
+    paddingLeft: 15
   },
   group: {
     marginLeft: 15,

--- a/app/properties/components/PropertyCard.js
+++ b/app/properties/components/PropertyCard.js
@@ -5,78 +5,43 @@ import { connect } from 'react-redux'
 import { Icon } from '../../core/components'
 
 class PropertyCard extends Component {
-  state = {
-    cardStyle: {},
-    cardWrapperStyle: {},
-    headerStyle: {}
-  }
-
-  _onLayout = (e) => {
-    this._calculateStyles(e)
-
-    if (this.props.onLayout) {
-      this.props.onLayout(e)
-    }
-  }
-
-  _calculateStyles = ({ nativeEvent: { layout: { width } } }) => {
-    width = Math.round(width)
-
-    if (width !== this._width) {
-      this.setState({
-        cardStyle: {
-          height: width * 1.5,
-          padding: width * 0.075
-        },
-        cardWrapperStyle: {
-          height: width * 1.425,
-          width: width * 0.925,
-          margin: width * -0.0325,
-          padding: width * 0.0325
-        },
-        headerStyle: {
-          height: width * 0.3,
-          backgroundColor: this.props.color
-        }
-      })
-
-      this._width = width
+  calculateStylesFromWidth(width) {
+    return {
+      card: {
+        height: width * 1.5,
+        padding: width * 0.075
+      },
+      wrapper: {
+        height: width * 1.425,
+        width: width * 0.925,
+        margin: width * -0.0325,
+        padding: width * 0.0325
+      },
+      header: {
+        height: width * 0.3
+      }
     }
   }
 
   render() {
     let {
       style,
+      width,
       property,
-      background,
-      header,
+      color,
       simple
     } = this.props
 
-    let cardStyle = [
-      styles.card,
-      this.state.cardStyle
-    ]
-
-    let cardWrapperStyle = [
-      styles.outline,
-      this.state.cardWrapperStyle
-    ]
-
-    let headerStyle = [
-      styles.header,
-      this.state.headerStyle
-    ]
+    let s = this.calculateStylesFromWidth(width)
+    let headerStyle = [styles.header, s.header, { backgroundColor: color }]
 
     return (
-      <View
-          style={style}
-          onLayout={this._onLayout}>
-        <View style={cardStyle}>
+      <View style={style}>
+        <View style={[styles.card, s.card]}>
           {simple ? (
             <View style={headerStyle}/>
           ) : (
-            <View style={cardWrapperStyle}>
+            <View style={[styles.wrapper, s.wrapper]}>
               <View style={[headerStyle, styles.headerWithText]}>
                 <Text style={styles.headerText}>
                   {property.name}
@@ -149,12 +114,12 @@ export default PropertyCardContainer
 
 const styles = StyleSheet.create({
   card: {
-    backgroundColor: 'white',
     borderWidth: 1,
     borderStyle: 'solid',
-    borderColor: 'rgba(0,0,0,0.2)'
+    borderColor: 'rgba(0,0,0,0.2)',
+    backgroundColor: 'white'
   },
-  outline: {
+  wrapper: {
     flex: 1,
     borderWidth: 2,
     borderStyle: 'solid',

--- a/app/properties/components/PropertyGroup.js
+++ b/app/properties/components/PropertyGroup.js
@@ -1,37 +1,17 @@
-import React, { Component } from 'react'
-import { View, StyleSheet } from 'react-native'
-import { connect } from 'react-redux'
+import React from 'react'
+import { View } from 'react-native'
 
 import PropertyCard from './PropertyCard'
 
-export default class PropertyGroup extends Component {
-  state = {
-    propertyStyle: 0
-  }
+const PropertyGroup = ({ properties, width, simple }) => (
+  <View style={{ width }}>
+    {properties.map((property, i) => (
+      <PropertyCard key={property._id}
+        style={i ? { marginTop: width * -1.2 } : null}
+        {...{ width, simple, property }}
+      />
+    ))}
+  </View>
+)
 
-  _updateLayout = ({ nativeEvent: { layout: { width } } }) => {
-    this.setState({
-      propertyStyle: {
-        marginTop: width * -1.2
-      }
-    })
-  }
-
-  render() {
-    let { properties, simple } = this.props
-
-    return (
-      <View>
-        {properties.map((p, i) => (
-          <PropertyCard key={p._id}
-            style={i ? this.state.propertyStyle : null}
-            onLayout={this._updateLayout}
-            property={p}
-            simple={simple}
-            index={i}
-          />
-        ))}
-      </View>
-    )
-  }
-}
+export default PropertyGroup


### PR DESCRIPTION
This addresses #15 but I don't think it is completely solved just yet. This drastically improves rendering a list of properties by minimizing setting the state in `onLayout` callbacks and also limits `PropertyList` to just rendering a set number of properties instead of all of them.

There is still a 200ms delay when rendering the bank view. This apparently comes from rendering `PropertyCard` components within the `Bank` component.

This bit of code can help determine how long it is taking to render a component:

```
componentWillMount() {
  this.start = performance.now()
}

componentDidMount() {
  console.log(
    `${this.constructor.name} mounted:`,
    performance.now() - this.start
  )
}
```

Going to keep this open until this is improved on a bit