### PR TITLE
Property transfer screens

### DIFF
--- a/app/src/game/player-select/player-select.js
+++ b/app/src/game/player-select/player-select.js
@@ -44,15 +44,15 @@ export default function PlayerSelect({
               {label}
             </Text>
 
-            <Text icon={selected?.token || 'bank'} upper>
-              {selected?.name ?? 'Bank'}
+            <Text icon={selected?.token || players[0]?.token || 'bank'} upper>
+              {selected?.name ?? players[0]?.name ?? 'Bank'}
             </Text>
           </span>
         )}
         data={players}
         itemIdKey="token"
         onSelect={onSelect}
-        selected={players.indexOf(selected)}
+        selected={selected ? players.indexOf(selected) : 0}
         renderItem={(player, { selected }) => (
           <div className={cx('token', { 'is-selected': selected })}>
             <Icon name={player.token}/>

--- a/app/src/game/property-transfer-form.js
+++ b/app/src/game/property-transfer-form.js
@@ -1,0 +1,65 @@
+import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { Container, Section } from '../ui/layout';
+import { CurrencyInput } from '../ui/forms';
+import Button from '../ui/button';
+
+import Property from './property';
+
+PropertyTransferForm.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  property: Property.propTypes.property,
+  onSubmit: PropTypes.func.isRequired
+};
+
+export default function PropertyTransferForm({
+  property,
+  loading,
+  onSubmit
+}) {
+  let [ value, setValue ] = useState(null);
+
+  let handleSubmit = useCallback(e => {
+    e.preventDefault();
+    onSubmit(value ?? property.price);
+  }, [onSubmit, value]);
+
+  return (
+    <Container
+      tagName="form"
+      onSubmit={handleSubmit}
+      data-test-property-transfer-form
+    >
+      <Section collapse justify="center" align="center">
+        <CurrencyInput
+          label="Enter amount"
+          value={value}
+          defaultValue={property.price}
+          onChange={v => setValue(v)}
+          onBlur={() => !value && setValue(null)}
+          color="secondary"
+          center
+          xl
+        />
+      </Section>
+
+      <Section row flex={4}>
+        <Property property={property} />
+      </Section>
+
+      <Section flex="none">
+        <Button
+          block
+          type="submit"
+          style="primary"
+          loading={loading}
+          disabled={loading || value === 0}
+          data-test-join-game-btn
+        >
+          Buy Property
+        </Button>
+      </Section>
+    </Container>
+  );
+}

--- a/app/src/game/property-transfer-form.js
+++ b/app/src/game/property-transfer-form.js
@@ -5,25 +5,34 @@ import { Container, Section } from '../ui/layout';
 import { CurrencyInput } from '../ui/forms';
 import Button from '../ui/button';
 
+import PlayerSelect from './player-select';
 import Property from './property';
 
 PropertyTransferForm.propTypes = {
-  loading: PropTypes.bool.isRequired,
+  players: PropTypes.array,
   property: Property.propTypes.property,
+  loading: PropTypes.bool.isRequired,
   onSubmit: PropTypes.func.isRequired
 };
 
 export default function PropertyTransferForm({
+  players,
   property,
   loading,
   onSubmit
 }) {
-  let [ value, setValue ] = useState(null);
+  let [ price, setPrice ] = useState(null);
+  let [ recipient, setRecipient ] = useState(players?.[0]);
+  let isPurchasing = property.owner === 'bank';
 
   let handleSubmit = useCallback(e => {
     e.preventDefault();
-    onSubmit(value ?? property.price);
-  }, [onSubmit, value]);
+    onSubmit((
+      isPurchasing
+        ? price ?? property.price
+        : recipient.token
+    ));
+  }, [onSubmit, price, recipient]);
 
   return (
     <Container
@@ -32,16 +41,25 @@ export default function PropertyTransferForm({
       data-test-property-transfer-form
     >
       <Section collapse justify="center" align="center">
-        <CurrencyInput
-          label="Enter amount"
-          value={value}
-          defaultValue={property.price}
-          onChange={v => setValue(v)}
-          onBlur={() => !value && setValue(null)}
-          color="secondary"
-          center
-          xl
-        />
+        {isPurchasing ? (
+          <CurrencyInput
+            label="Enter amount"
+            value={price}
+            defaultValue={property.price}
+            onChange={v => setPrice(v)}
+            onBlur={() => !price && setPrice(null)}
+            color="secondary"
+            center
+            xl
+          />
+        ) : (
+          <PlayerSelect
+            label="To:"
+            players={players || []}
+            selected={recipient}
+            onSelect={setRecipient}
+          />
+        )}
       </Section>
 
       <Section row flex={4}>
@@ -54,10 +72,9 @@ export default function PropertyTransferForm({
           type="submit"
           style="primary"
           loading={loading}
-          disabled={loading || value === 0}
-          data-test-join-game-btn
+          disabled={loading || (isPurchasing ? price === 0 : !recipient)}
         >
-          Buy Property
+          {`${isPurchasing ? 'Buy' : 'Transfer'} Property`}
         </Button>
       </Section>
     </Container>

--- a/app/src/game/property/property.css
+++ b/app/src/game/property/property.css
@@ -18,6 +18,12 @@
     margin-right: var(--pad-xs);
     filter: drop-shadow(var(--shadow-sm));
   }
+
+  .transfer-btn {
+    float: right;
+    font-size: var(--size-sm);
+    color: var(--color-text-dark);
+  }
 }
 
 .card {

--- a/app/src/game/property/property.css
+++ b/app/src/game/property/property.css
@@ -76,6 +76,16 @@
   button > span:first-child {
     margin-right: 0.25em;
   }
+
+  .buy-other {
+    position: absolute;
+    font-size: var(--size-sm);
+    color: var(--color-text-dark);
+    top: auto;
+    bottom: 0;
+    left: 50%;
+    transform: translatex(-50%);
+  }
 }
 
 .swatch {

--- a/app/src/game/property/property.js
+++ b/app/src/game/property/property.js
@@ -59,6 +59,7 @@ export default function Property({
   onUnmortgage
 }) {
   let {
+    room,
     player,
     config: {
       mortgageRate,
@@ -237,16 +238,28 @@ export default function Property({
 
       <div className={styles.actions}>
         {owner === 'bank' && onPurchase && (
-          <Button
-            block
-            hollow
-            style="primary"
-            onClick={() => onPurchase(id, price)}
-            data-test-property-buy-btn
-          >
-            Buy for &zwj;
-            <Currency value={price} data-test-property-price/>
-          </Button>
+          <>
+            <Button
+              block
+              hollow
+              style="primary"
+              onClick={() => onPurchase(id, price)}
+              data-test-property-buy-btn
+            >
+              Buy for &zwj;
+              <Currency value={price} data-test-property-price/>
+            </Button>
+
+            <Button
+              block
+              hollow
+              className={styles['buy-other']}
+              linkTo={`/${room}/${id}/buy`}
+              data-test-property-buy-other-btn
+            >
+              enter other amount
+            </Button>
+          </>
         )}
         {owner !== 'bank' && !isOwn && !mortgaged && onRent && (
           <Button

--- a/app/src/game/property/property.js
+++ b/app/src/game/property/property.js
@@ -101,6 +101,17 @@ export default function Property({
           ) : Array(buildings).fill().map((_, i) => (
             <Icon name="building" className={cx('house')} key={i} data-test-property-house/>
           ))}
+
+          {isOwn && !monopoly && !mortgaged && (
+            <Button
+              hollow
+              linkTo={`/${room}/${id}/transfer`}
+              className={cx('transfer-btn')}
+              data-test-property-transfer-btn
+            >
+              Transfer
+            </Button>
+          )}
         </div>
       )}
 

--- a/app/src/root.js
+++ b/app/src/root.js
@@ -16,6 +16,7 @@ import BankScreen from './screens/bank';
 import TransferScreen from './screens/transfer';
 import PropertiesScreen from './screens/properties';
 import BuyPropertyScreen from './screens/buy-property';
+import TransferPropertyScreen from './screens/transfer-property';
 import SandboxScreen from './screens/sandbox';
 
 AppRoot.propTypes = {
@@ -44,6 +45,7 @@ function AppRoot({
             <Route path={`/${roompath}/properties`} render={PropertiesScreen}/>
             <Route path={`/${roompath}/:token/properties`} render={PropertiesScreen}/>
             <Route path={`/${roompath}/:id/buy`} render={BuyPropertyScreen}/>
+            <Route path={`/${roompath}/:id/transfer`} render={TransferPropertyScreen}/>
           </Route>
 
           {process.env.NODE_ENV === 'development' && (

--- a/app/src/root.js
+++ b/app/src/root.js
@@ -15,6 +15,7 @@ import DashboardScreen from './screens/dashboard';
 import BankScreen from './screens/bank';
 import TransferScreen from './screens/transfer';
 import PropertiesScreen from './screens/properties';
+import BuyPropertyScreen from './screens/buy-property';
 import SandboxScreen from './screens/sandbox';
 
 AppRoot.propTypes = {
@@ -42,6 +43,7 @@ function AppRoot({
             <Route path={`/${roompath}/transfer`} render={TransferScreen}/>
             <Route path={`/${roompath}/properties`} render={PropertiesScreen}/>
             <Route path={`/${roompath}/:token/properties`} render={PropertiesScreen}/>
+            <Route path={`/${roompath}/:id/buy`} render={BuyPropertyScreen}/>
           </Route>
 
           {process.env.NODE_ENV === 'development' && (

--- a/app/src/screens/buy-property.js
+++ b/app/src/screens/buy-property.js
@@ -31,7 +31,7 @@ export default function BuyPropertyScreen({ push, params }) {
   }, [ok]);
 
   return (
-    <Container data-test-transfer>
+    <Container data-test-property-transfer>
       <NavBar
         showBack={`/${room}/properties`}
         roomCode={room}

--- a/app/src/screens/buy-property.js
+++ b/app/src/screens/buy-property.js
@@ -1,0 +1,56 @@
+import React, { useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import { useGame, useEmit } from '../api';
+import { useProperty } from '../helpers/hooks';
+
+import { Container } from '../ui/layout';
+import { Text } from '../ui/typography';
+import NavBar from '../ui/nav-bar';
+
+import PropertyTransferForm from '../game/property-transfer-form';
+
+BuyPropertyScreen.propTypes = {
+  push: PropTypes.func.isRequired,
+  params: PropTypes.shape({
+    id: PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default function BuyPropertyScreen({ push, params }) {
+  let { room } = useGame();
+  let [ buy, { pending, ok }] = useEmit('property:buy');
+  let property = useProperty(params.id);
+
+  let handlePurchase = useCallback((amount) => {
+    if (!pending) buy(params.id, amount);
+  }, [pending, buy]);
+
+  useEffect(() => {
+    if (property.owner !== 'bank' || ok) push(`/${room}`);
+  }, [ok]);
+
+  return (
+    <Container data-test-transfer>
+      <NavBar
+        showBack={`/${room}/properties`}
+        roomCode={room}
+      >
+        <Text
+          upper
+          icon="transfer"
+          color="lighter"
+          data-test-screen-title
+        >
+          Purchase
+        </Text>
+      </NavBar>
+
+      <PropertyTransferForm
+        property={property}
+        loading={pending}
+        onSubmit={handlePurchase}
+      />
+    </Container>
+  );
+}

--- a/app/src/screens/properties.js
+++ b/app/src/screens/properties.js
@@ -28,27 +28,27 @@ export default function PropertiesScreen({ push, params }) {
 
   let handlePurchase = useCallback((id, amount) => {
     if (!buyResponse.pending) buyProperty(id, amount);
-  }, [buyProperty]);
+  }, [buyResponse.pending, buyProperty]);
 
   let handleRent = useCallback((id, amount) => {
     if (!rentResponse.pending) rentProperty(id, amount);
-  }, [rentProperty]);
+  }, [rentResponse.pending, rentProperty]);
 
   let handleImprove = useCallback(id => {
     if (!improveResponse.pending) improveProperty(id);
-  }, [improveProperty]);
+  }, [improveResponse.pending, improveProperty]);
 
   let handleUnimprove = useCallback(id => {
     if (!unimproveResponse.pending) unimproveProperty(id);
-  }, [unimproveProperty]);
+  }, [unimproveResponse.pending, unimproveProperty]);
 
   let handleMortgage = useCallback(id => {
     if (!mortgageResponse.pending) mortgageProperty(id);
-  }, [mortgageProperty]);
+  }, [mortgageResponse.pending, mortgageProperty]);
 
   let handleUnmortgage = useCallback(id => {
     if (!unmortgageResponse.pending) unmortgageProperty(id);
-  }, [unimproveProperty]);
+  }, [unmortgageResponse.pending, unmortgageProperty]);
 
   useEffect(() => {
     if (buyResponse.ok || rentResponse.ok) push(`/${room}`);

--- a/app/src/screens/transfer-property.js
+++ b/app/src/screens/transfer-property.js
@@ -1,0 +1,58 @@
+import React, { useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import { useGame, useEmit } from '../api';
+import { usePlayers, useProperty } from '../helpers/hooks';
+
+import { Container } from '../ui/layout';
+import { Text } from '../ui/typography';
+import NavBar from '../ui/nav-bar';
+
+import PropertyTransferForm from '../game/property-transfer-form';
+
+TransferPropertyScreen.propTypes = {
+  push: PropTypes.func.isRequired,
+  params: PropTypes.shape({
+    id: PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default function TransferPropertyScreen({ push, params }) {
+  let { room, player } = useGame();
+  let [ transfer, { pending, ok }] = useEmit('property:transfer');
+  let players = usePlayers({ exclude: [player.token] });
+  let property = useProperty(params.id);
+
+  let handleTransfer = useCallback((token) => {
+    if (!pending) transfer(params.id, token);
+  }, [pending, transfer]);
+
+  useEffect(() => {
+    if (property.owner !== player.token || ok) push(`/${room}`);
+  }, [ok]);
+
+  return (
+    <Container data-test-property-transfer>
+      <NavBar
+        showBack={`/${room}/properties`}
+        roomCode={room}
+      >
+        <Text
+          upper
+          icon="transfer"
+          color="lighter"
+          data-test-screen-title
+        >
+          Transfer
+        </Text>
+      </NavBar>
+
+      <PropertyTransferForm
+        players={players}
+        property={property}
+        loading={pending}
+        onSubmit={handleTransfer}
+      />
+    </Container>
+  );
+}

--- a/app/src/ui/forms/currency-input.js
+++ b/app/src/ui/forms/currency-input.js
@@ -10,6 +10,7 @@ const cx = classNames.bind(styles);
 CurrencyInput.propTypes = {
   value: PropTypes.number,
   defaultValue: PropTypes.number,
+  label: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func
@@ -18,6 +19,7 @@ CurrencyInput.propTypes = {
 export default function CurrencyInput({
   value,
   defaultValue,
+  label,
   onChange,
   onFocus,
   onBlur,
@@ -32,6 +34,12 @@ export default function CurrencyInput({
       className={cx('currency-input')}
       data-test-currency-input
     >
+      {label && (
+        <span className={cx('label')}>
+          {label}
+        </span>
+      )}
+
       <input
         value={value || '0'}
         onChange={handleChange}
@@ -42,6 +50,7 @@ export default function CurrencyInput({
 
       <Currency
         value={value == null ? defaultValue : value}
+        data-test-currency-value
         {...props}
       />
     </label>

--- a/app/src/ui/forms/forms.css
+++ b/app/src/ui/forms/forms.css
@@ -146,4 +146,8 @@
   input[type="number"] {
     @extend %visually-hidden;
   }
+
+  .label {
+    justify-content: center;
+  }
 }

--- a/app/test/acceptance/buy-property.test.js
+++ b/app/test/acceptance/buy-property.test.js
@@ -1,0 +1,102 @@
+import { setupApplication } from '../helpers';
+
+import TransferPropertyInteractor from '../interactors/transfer-property';
+import DashboardInteractor from '../interactors/dashboard';
+
+describe('BuyPropertyScreen', () => {
+  const transfer = new TransferPropertyInteractor();
+  const dashboard = new DashboardInteractor();
+
+  setupApplication(async function () {
+    await this.grm.mock({
+      room: 't35tt',
+      players: [
+        { token: 'top-hat' }
+      ]
+    });
+
+    this.ls.data.room = 't35tt',
+    this.ls.data.player = { name: 'PLAYER 1', token: 'top-hat' };
+    await transfer.visit('/t35tt/oriental-avenue/buy');
+  });
+
+  it('shows the buy property screen', async () => {
+    await transfer
+      .assert.exists()
+      .percySnapshot('buy');
+  });
+
+  it('shows the room code', async () => {
+    await transfer
+      .assert.roomCode('T35TT');
+  });
+
+  it('shows a transfer icon and purchase heading', async () => {
+    await transfer
+      .assert.heading.text('PURCHASE')
+      .assert.heading.icon('transfer');
+  });
+
+  it('shows a back button linked to the properties screen', async () => {
+    await transfer
+      .assert.backBtn.exists()
+      .assert.backBtn.attribute('href', '/t35tt/properties');
+  });
+
+  it('goes to the properties screen when clicking the back button', async () => {
+    await transfer
+      .backBtn.click()
+      .assert.location('/t35tt/properties')
+      .assert.not.exists();
+  });
+
+  it('shows a default amount for the property\'s price', async () => {
+    await transfer
+      .assert.amount('100');
+  });
+
+  it('shows the property card', async () => {
+    await transfer
+      .assert.property('ORIENTAL AVENUE');
+  });
+
+  it('can enter a custom amount', async () => {
+    await transfer
+      .input.type('30')
+      .assert.amount('30')
+      .percySnapshot('buy custom amount');
+  });
+
+  it('restores the defaults amount on blur when the amount is 0', async () => {
+    await transfer
+      .input.focus()
+      .input.type('0')
+      .assert.amount('0')
+      .input.blur()
+      .assert.amount('100');
+  });
+
+  it('clears the default withdrawl amount after pressing backspace', async () => {
+    await transfer
+      .assert.amount('100')
+      .input.press('Backspace')
+      .assert.amount('0');
+  });
+
+  it('has a submit button', async () => {
+    await transfer
+      .assert.submit.exists();
+  });
+
+  it('navigates to the dashboard after purchasing', async () => {
+    await transfer
+      .input.type('20')
+      .submit.click();
+    await dashboard
+      .assert.exists()
+      .assert.toast.message('YOU purchased Oriental Avenue')
+      .assert.summary.balance('1,480');
+    await transfer
+      .percySnapshot('after purchase');
+  });
+});

--- a/app/test/acceptance/buy-property.test.js
+++ b/app/test/acceptance/buy-property.test.js
@@ -76,7 +76,7 @@ describe('BuyPropertyScreen', () => {
       .assert.amount('100');
   });
 
-  it('clears the default withdrawl amount after pressing backspace', async () => {
+  it('clears the default amount after pressing backspace', async () => {
     await transfer
       .assert.amount('100')
       .input.press('Backspace')

--- a/app/test/acceptance/properties.test.js
+++ b/app/test/acceptance/properties.test.js
@@ -294,6 +294,16 @@ describe('PropertiesScreen', () => {
         .assert.property.not.mortgaged()
         .percySnapshot('own after unmortgaging');
     });
+
+    it('shows a transfer button when not mortgaged nor a monopoly', async () => {
+      await search
+        .input.type('med')
+        .assert.property.name('MEDITERRANEAN AVENUE')
+        .assert.property.not.mortgaged()
+        .assert.property.improveBtn.not.exists()
+        .assert.property.transferBtn.exists()
+        .assert.property.transferBtn.attribute('href', '/t35tt/mediterranean-avenue/transfer');
+    });
   });
 
   describe('other player properties', () => {

--- a/app/test/acceptance/properties.test.js
+++ b/app/test/acceptance/properties.test.js
@@ -146,6 +146,15 @@ describe('PropertiesScreen', () => {
         .percySnapshot('with a buy button');
     });
 
+    it('shows an "enter other amount" button', async () => {
+      await search
+        .input.type('ill')
+        .assert.property.name('ILLINOIS AVENUE')
+        .assert.property.otherBtn.exists()
+        .assert.property.otherBtn.text('enter other amount')
+        .assert.property.otherBtn.attribute('href', '/t35tt/illinois-avenue/buy');
+    });
+
     it('navigates to the dashboard after buying a property', async () => {
       await search
         .input.type('ill')

--- a/app/test/acceptance/transfer-property.test.js
+++ b/app/test/acceptance/transfer-property.test.js
@@ -1,0 +1,91 @@
+import { setupApplication } from '../helpers';
+
+import TransferPropertyInteractor from '../interactors/transfer-property';
+import DashboardInteractor from '../interactors/dashboard';
+
+describe('TransferPropertyScreen', () => {
+  const transfer = new TransferPropertyInteractor();
+  const dashboard = new DashboardInteractor();
+
+  setupApplication(async function () {
+    await this.grm.mock({
+      room: 't35tt',
+      players: [
+        { token: 'top-hat' },
+        { token: 'automobile' },
+        { token: 'thimble' }
+      ],
+      properties: [
+        { id: 'baltic-avenue', owner: 'top-hat' }
+      ]
+    });
+
+    this.ls.data.room = 't35tt',
+    this.ls.data.player = { name: 'PLAYER 1', token: 'top-hat' };
+    await transfer.visit('/t35tt/baltic-avenue/transfer');
+  });
+
+  it('shows the transfter property screen', async () => {
+    await transfer
+      .assert.exists()
+      .percySnapshot('transfer');
+  });
+
+  it('shows the room code', async () => {
+    await transfer
+      .assert.roomCode('T35TT');
+  });
+
+  it('shows a transfer icon and heading', async () => {
+    await transfer
+      .assert.heading.text('TRANSFER')
+      .assert.heading.icon('transfer');
+  });
+
+  it('shows a back button linked to the properties screen', async () => {
+    await transfer
+      .assert.backBtn.exists()
+      .assert.backBtn.attribute('href', '/t35tt/properties');
+  });
+
+  it('goes to the properties screen when clicking the back button', async () => {
+    await transfer
+      .backBtn.click()
+      .assert.location('/t35tt/properties')
+      .assert.not.exists();
+  });
+
+  it('has the first other player selected by default', async () => {
+    await transfer
+      .assert.recipient('automobile').selected();
+  });
+
+  it('shows the property card', async () => {
+    await transfer
+      .assert.property('BALTIC AVENUE');
+  });
+
+  it('can choose another player', async () => {
+    await transfer
+      .recipient('thimble').select()
+      .assert.recipient('thimble').selected()
+      .percySnapshot('other player chosen');
+  });
+
+  it('has a submit button', async () => {
+    await transfer
+      .assert.submit.exists();
+  });
+
+  it('navigates to the dashboard after transferring', async () => {
+    await transfer
+      .submit.click();
+    await dashboard
+      .assert.exists()
+      .assert.toast.message('PLAYER 2 received Baltic Avenue')
+      .assert.summary.property('baltic-avenue').not.exists()
+      .assert.card(0).property('baltic-avenue').exists();
+    await transfer
+      .percySnapshot('after transfer');
+  });
+});

--- a/app/test/interactors/property-search.js
+++ b/app/test/interactors/property-search.js
@@ -32,6 +32,7 @@ import GameRoomInteractor from './game-room';
     mortgage: text('[data-test-property-mortgage-value]'),
     cost: collection('[data-test-property-build-cost]'),
     buyBtn: scoped('[data-test-property-buy-btn]'),
+    otherBtn: scoped('[data-test-property-buy-other-btn]'),
     rentBtn: scoped('[data-test-property-rent-btn]'),
     mortgageBtn: scoped('[data-test-property-mortgage-btn]'),
     unmortgageBtn: scoped('[data-test-property-unmortgage-btn]'),

--- a/app/test/interactors/property-search.js
+++ b/app/test/interactors/property-search.js
@@ -33,6 +33,7 @@ import GameRoomInteractor from './game-room';
     cost: collection('[data-test-property-build-cost]'),
     buyBtn: scoped('[data-test-property-buy-btn]'),
     otherBtn: scoped('[data-test-property-buy-other-btn]'),
+    transferBtn: scoped('[data-test-property-transfer-btn]'),
     rentBtn: scoped('[data-test-property-rent-btn]'),
     mortgageBtn: scoped('[data-test-property-mortgage-btn]'),
     unmortgageBtn: scoped('[data-test-property-unmortgage-btn]'),

--- a/app/test/interactors/transfer-property.js
+++ b/app/test/interactors/transfer-property.js
@@ -1,0 +1,15 @@
+import interactor, { text, scoped } from 'interactor.js';
+import GameRoomInteractor from './game-room';
+
+@interactor class TransferPropertyInteractor extends GameRoomInteractor {
+  static defaultScope = '[data-test-transfer]';
+  static snapshotTitle = 'Transfer Property';
+
+  backBtn = scoped('[data-test-back]');
+  amount = text('[data-test-currency-value]');
+  input = scoped('[data-test-currency-input] input');
+  property = text('[data-test-property-name]');
+  submit = scoped('button[type="submit"]');
+}
+
+export default TransferPropertyInteractor;

--- a/app/test/interactors/transfer-property.js
+++ b/app/test/interactors/transfer-property.js
@@ -1,4 +1,4 @@
-import interactor, { text, scoped } from 'interactor.js';
+import interactor, { check, checked, collection, text, scoped } from 'interactor.js';
 import GameRoomInteractor from './game-room';
 
 @interactor class TransferPropertyInteractor extends GameRoomInteractor {
@@ -8,6 +8,15 @@ import GameRoomInteractor from './game-room';
   backBtn = scoped('[data-test-back]');
   amount = text('[data-test-currency-value]');
   input = scoped('[data-test-currency-input] input');
+
+  recipient = collection(token => (
+    `[data-test-player-select] [data-test-radio-item="${token}"]`
+  ), {
+    select: check('input[type="radio"]'),
+    selected: checked('input[type="radio"]'),
+    name: text('[data-test-player-select-name]')
+  });
+
   property = text('[data-test-property-name]');
   submit = scoped('button[type="submit"]');
 }

--- a/app/test/interactors/transfer-property.js
+++ b/app/test/interactors/transfer-property.js
@@ -2,7 +2,7 @@ import interactor, { text, scoped } from 'interactor.js';
 import GameRoomInteractor from './game-room';
 
 @interactor class TransferPropertyInteractor extends GameRoomInteractor {
-  static defaultScope = '[data-test-transfer]';
+  static defaultScope = '[data-test-property-transfer]';
   static snapshotTitle = 'Transfer Property';
 
   backBtn = scoped('[data-test-back]');


### PR DESCRIPTION
## Purpose

- After a verbal auction, a player should be able to purchase a property for an amount other than the property's price.

- For verbal trades, a player should be able to transfer their own property to another player.

## Approach

Both of these screens can be combined since they both involve ownership of a property. For purchasing for another amount, a currency input is show. For transferring to another player, a player select is shown.