### PR TITLE
Track game history and veto events (server only)

### DIFF
--- a/server/src/helpers.js
+++ b/server/src/helpers.js
@@ -1,4 +1,4 @@
-const { assign, entries } = Object;
+const { assign, entries, getPrototypeOf } = Object;
 
 // computes common meta information from the state
 export function meta(state, data) {
@@ -37,4 +37,9 @@ export function randomString(length = 5) {
   }
 
   return result;
+}
+
+// returns true if an object is a plain object
+export function isPojo(obj) {
+  return !!obj && getPrototypeOf(obj) === Object.prototype;
 }

--- a/server/src/history.js
+++ b/server/src/history.js
@@ -1,0 +1,63 @@
+import { isPojo } from './helpers';
+
+const { assign, keys } = Object;
+const { isArray } = Array;
+
+// deeply constructs a "diff" between two objects; only tracking values from `a`
+function diff(a, b) {
+  let allKeys = keys(a).concat(keys(b))
+    .filter((v, i, k) => k.indexOf(v) === i);
+
+  return allKeys.reduce((d, k) => {
+    // no diff
+    if (a[k] === b[k]) {
+      return d;
+    // deep diff
+    } else if ((isPojo(a[k]) && isPojo(b[k])) || (isArray(a[k]) && isArray(b[k]))) {
+      return assign(d, { [k]: diff(a[k], b[k]) });
+    // track diff
+    } else {
+      return assign(d, { [k]: a[k] });
+    }
+  }, isArray(a) ? [] : {});
+}
+
+// deeply merges two objects, returning a new object
+function merge(a, b) {
+  return keys(b).reduce((c, k) => {
+    // no merge
+    if (a[k] === b[k]) {
+      return c;
+    // deep merge
+    } else if ((isPojo(a[k]) && isPojo(b[k])) || (isArray(a[k]) && isArray(b[k]))) {
+      return assign(c, { [k]: merge(a[k], b[k]) });
+    // override merge
+    } else {
+      return assign(c, { [k]: b[k] });
+    }
+  }, isArray(a) ? [...a] : { ...a });
+}
+
+// adds a new diff to the history of the next state
+export function recordHistory(prev, next) {
+  let state = { ...next, timestamp: Date.now() };
+  state.history = [diff(prev, state), ...(state.history || [])];
+  return state;
+}
+
+// recursively merges previous state diffs up until the timestamp
+export function getStateBefore(state, timestamp) {
+  let entry, message;
+
+  for (entry of (state.history || [])) {
+    if (entry.timestamp <= timestamp) {
+      // record the message from the last overwritten state
+      message = state.notice?.message;
+      state = merge(state, entry);
+    } else {
+      break;
+    }
+  }
+
+  return [state, message];
+}

--- a/server/src/poll.js
+++ b/server/src/poll.js
@@ -2,14 +2,10 @@ const { from: toArray } = Array;
 
 // polls run for a limited time or until all included players have voted
 export default class Poll {
-  // the current connected players and poll timeout are required
+  // included players and poll timeout are required
   constructor(players, timeout) {
-    // tracks votes for active players
-    this.votes = toArray(players.entries())
-      .reduce((votes, [player, token]) => (
-        token ? votes.set(player, 0) : votes
-      ), new Map());
-
+    // tracks votes for included players
+    this.votes = new Map(players.map(p => [p, 0]));
     // the poll timeout
     this.timeout = timeout;
   }

--- a/server/src/state/utils.js
+++ b/server/src/state/utils.js
@@ -1,3 +1,7 @@
+import { isPojo } from '../helpers';
+
+const { isArray } = Array;
+
 // pipe helper; accepts an array or list of functions and skips non truthy functions
 export function pipe(...fns) {
   if (fns.length === 1 && Array.isArray(fns[0])) fns = fns[0];
@@ -9,11 +13,11 @@ export function reduce(path, reducer) {
   // creates a middleware-like pattern that recurses the provided path inwards
   // towards the inner-most value and builds new state outwards
   return path.split('.').reduceRight((next, key) => state => {
-    if (state && Object.getPrototypeOf(state) === Object.prototype) {
+    if (state && isPojo(state)) {
       // create a new object
       return { ...state, [key]: next(state[key]) };
 
-    } else if (Array.isArray(state)) {
+    } else if (isArray(state)) {
       // create a new array
       return [...state.slice(0, key), next(state[key]), ...state.slice(key + 1)];
 

--- a/server/test/acceptance/vetoing-events.test.js
+++ b/server/test/acceptance/vetoing-events.test.js
@@ -1,0 +1,122 @@
+import expect from 'expect';
+import { setupForTesting } from '../helpers';
+
+describe('vetoing events', () => {
+  let socket1, socket2, game;
+
+  setupForTesting(async function () {
+    game = await this.grm.mock({
+      room: 't35tt',
+      config: {
+        pollTimeout: 50
+      },
+      players: [
+        { token: 'top-hat' },
+        { token: 'automobile' }
+      ],
+      properties: [
+        { id: 'oriental-avenue', owner: 'top-hat' },
+        { id: 'vermont-avenue', owner: 'top-hat' }
+      ]
+    });
+
+    socket1 = await this.socket([
+      ['room:connect', 't35tt'],
+      ['game:join', 'PLAYER 1', 'top-hat']
+    ]);
+
+    socket2 = await this.socket([
+      ['room:connect', 't35tt'],
+      ['game:join', 'PLAYER 2', 'automobile']
+    ]);
+  });
+
+  it('does nothing if the player has not joined', async function () {
+    let socket3 = await this.socket([['room:connect', 't35tt']]);
+    await expect(socket3.send('game:veto', 'not-applicable'))
+      .rejects.toThrow('no response');
+  });
+
+  it('polls existing players before vetoing', async () => {
+    [game] = await socket1.send('property:buy', 'boardwalk', 1);
+
+    socket1.expect('poll:new').then(([pid, message]) => {
+      expect(pid).toEqual(expect.any(String));
+      expect(message).toEqual('PLAYER 2 vetos when "PLAYER 1 purchased Boardwalk"');
+      socket1.send('poll:vote', pid, true);
+    });
+
+    expect(game).toHaveProperty('notice.message', 'PLAYER 1 purchased Boardwalk');
+    [game] = await socket2.send('game:veto', game.timestamp);
+    expect(game).toHaveProperty('notice', null);
+  });
+
+  it('responds with an error when existing players vote no', async () => {
+    [game] = await socket1.send('property:buy', 'boardwalk', 1);
+
+    socket1.expect('poll:new').then(([pid]) => (
+      socket1.send('poll:vote', pid, false)
+    ));
+
+    await expect(socket2.send('game:veto', game.timestamp))
+      .rejects.toThrow('Your friends did not agree to veto');
+  });
+
+  it('responds with an error when existing players do not vote in time', async () => {
+    [game] = await socket1.send('property:buy', 'boardwalk', 1);
+
+    await expect(socket2.send('game:veto', game.timestamp))
+      .rejects.toThrow('Your friends did not agree to veto');
+  });
+
+  it('notifies players and reverts the game state', async () => {
+    [game] = await socket1.send('property:buy', 'boardwalk', 1);
+
+    socket2.send('game:veto', game.timestamp);
+    socket1.expect('poll:new').then(([pid]) => (
+      socket1.send('poll:vote', pid, true)
+    ));
+
+    expect(game).toHaveProperty('notice.message', 'PLAYER 1 purchased Boardwalk');
+    expect(game).toHaveProperty('properties.boardwalk.owner', 'top-hat');
+    expect(game).toHaveProperty('players.top-hat.balance', 1499);
+
+    [game] = await socket1.expect('game:revert');
+
+    expect(game).toHaveProperty('notice', null);
+    expect(game).toHaveProperty('properties.boardwalk.owner', 'bank');
+    expect(game).toHaveProperty('players.top-hat.balance', 1500);
+  });
+
+  it('responds with an error when there is no corresponding game state', async () => {
+    await expect(socket1.send('game:veto', game.timestamp))
+      .rejects.toThrow('No matching event found');
+  });
+
+  it('can revert multiple events', async () => {
+    [game] = await socket1.send('property:buy', 'boardwalk', 1);
+
+    expect(game).toHaveProperty('notice.message', 'PLAYER 1 purchased Boardwalk');
+    expect(game).toHaveProperty('properties.boardwalk.owner', 'top-hat');
+    expect(game).toHaveProperty('players.top-hat.balance', 1499);
+    let timestamp = game.timestamp;
+
+    [game] = await socket1.send('property:buy', 'park-place', 1);
+
+    expect(game).toHaveProperty('notice.message', 'PLAYER 1 purchased Park Place');
+    expect(game).toHaveProperty('properties.park-place.owner', 'top-hat');
+    expect(game).toHaveProperty('players.top-hat.balance', 1498);
+
+    socket2.send('game:veto', timestamp);
+    socket1.expect('poll:new').then(([pid]) => {
+      return socket1.send('poll:vote', pid, true);
+    });
+
+    [game] = await socket1.expect('game:revert');
+
+    expect(game).toHaveProperty('notice', null);
+    expect(game).toHaveProperty('properties.park-place.owner', 'bank');
+    expect(game).toHaveProperty('properties.boardwalk.owner', 'bank');
+    expect(game).toHaveProperty('players.top-hat.balance', 1500);
+  });
+});

--- a/server/themes/classic/messages.yml
+++ b/server/themes/classic/messages.yml
@@ -7,6 +7,7 @@ notice:
     paid-other: '{{player.name}} paid {{other.name}} ${{amount}}'
     bankrupt: '{{player.name}} went bankrupt'
     other-bankrupt: '{{other.name}} bankrupt {{player.name}}'
+    veto: '{{player.name}} vetos when "{{message}}"'
 
   property:
     bought: '{{player.name}} purchased {{property.name}}'
@@ -21,6 +22,7 @@ error:
   common:
     bank-low: 'Bank funds are insufficient'
     negative-amount: 'Amount must not be negative'
+    event-not-found: 'No matching event found'
 
   player:
     playing: 'Player already joined'
@@ -31,6 +33,7 @@ error:
     denied: 'Sorry, your friends hate you'
     empty-room: 'Nobody is in the room'
     balance: 'Insufficient balance'
+    veto-denied: 'Your friends did not agree to veto'
 
   property:
     unowned: '{{property.name}} is unowned'


### PR DESCRIPTION
## Purpose

If players make a mistake or maliciously trigger unwanted events, those events should be undoable. 

## Approach

Adds some helpers that add a diff to the history of the game state on every update. Then, through a `game:veto` action, a player can poll other players to revert the game to a previous state. The previous state is determined by recursively reverting up to the diff just before a provided timestamp. 

Messaging was added for timestamps that have no effect and for when the poll returns a falsey result (majority of other players voted no, or didn't vote in time).

Rather than emitting a `game:update` event, reverting a game will emit a `game:revert` event. This could help alleviate possible issues in the frontend when we show an "old" toast for the new reverted state.