### PR TITLE
Autofill persisted player data

### DIFF
--- a/app/src/game/join-game-form.js
+++ b/app/src/game/join-game-form.js
@@ -9,20 +9,25 @@ import Button from '../ui/button';
 import TokenSelect from './token-select';
 
 JoinGameForm.propTypes = {
+  autofill: PropTypes.shape({
+    name: PropTypes.string,
+    token: PropTypes.string
+  }),
   onSubmit: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   error: PropTypes.string
 };
 
 export default function JoinGameForm({
+  autofill,
   onSubmit,
   loading,
   error
 }) {
   let players = usePlayers();
   let { playerTokens: tokens = [] } = useConfig();
-  let [ name, setName ] = useState('');
-  let [ token, setToken ] = useState('');
+  let [ name, setName ] = useState(autofill?.name ?? '');
+  let [ token, setToken ] = useState(autofill?.token ?? '');
 
   let existing = useMemo(() => players.find(player => (
     !player.active && player.name.toUpperCase() === name

--- a/app/src/screens/join-game.js
+++ b/app/src/screens/join-game.js
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { useGame, useEmitter, useEmit } from '../api';
+import ls from '../helpers/storage';
 
 import { Container, Section } from '../ui/layout';
 import { Heading } from '../ui/typography';
@@ -27,6 +28,7 @@ export default function JoinGameScreen({
   let { disconnect } = useEmitter();
   let [ connect, connected ] = useEmit('room:connect');
   let [ join, joined ] = useEmit('game:join');
+  let persisted = useMemo(() => ls.load('player'), []);
 
   let handleJoinGame = useCallback((name, token) => {
     if (!joined.pending) join(name, token);
@@ -66,6 +68,7 @@ export default function JoinGameScreen({
           </NavBar>
 
           <JoinGameForm
+            autofill={persisted}
             loading={joined.pending}
             error={joined.error?.message}
             onSubmit={handleJoinGame}

--- a/app/test/acceptance/join-game.test.js
+++ b/app/test/acceptance/join-game.test.js
@@ -341,6 +341,20 @@ describe('JoinGameScreen', () => {
     });
   });
 
+  describe('with persisted player data', () => {
+    beforeEach(async function() {
+      this.ls.data.player = { name: 'PLAYER 1', token: 'top-hat' };
+      await joinGame.visit();
+    });
+
+    it('should autofill the name and token', async () => {
+      await joinGame
+        .assert.nameInput.value('PLAYER 1')
+        .assert.tokens.item('top-hat').selected()
+        .assert.submitBtn.not.disabled();
+    });
+  });
+
   describe('with a non-existent room', () => {
     beforeEach(async () => {
       await joinGame.visit('/f4k3e/join');


### PR DESCRIPTION
## Purpose

When joining a new game, your name typically hasn't changed from the last time you played a game, so it would be nice to autofill that data from localstorage. We can assume the previous token is preferred and also autoselect the persisted token.

## Approach

Add an `autofill` property to the JoinGameForm that is used when determining the default state of the name and token fields. This autofill property is then populated by loading persisted player data from localstorage.