### PR TITLE
Reduce NavBar boilerplate

### DIFF
--- a/app/src/screens/bank.js
+++ b/app/src/screens/bank.js
@@ -13,18 +13,11 @@ export default function BankScreen() {
   return (
     <Container data-test-bank>
       <NavBar
+        title="Bank"
+        titleIcon="bank"
         showBack={`/${room}`}
         roomCode={room}
-      >
-        <Text
-          upper
-          icon="bank"
-          color="lighter"
-          data-test-screen-title
-        >
-          Bank
-        </Text>
-      </NavBar>
+      />
 
       <Section>
         <Card linkTo={`/${room}/transfer`}>

--- a/app/src/screens/buy-property.js
+++ b/app/src/screens/buy-property.js
@@ -5,7 +5,6 @@ import { useGame, useEmit } from '../api';
 import { useProperty } from '../helpers/hooks';
 
 import { Container } from '../ui/layout';
-import { Text } from '../ui/typography';
 import NavBar from '../ui/nav-bar';
 
 import PropertyTransferForm from '../game/property-transfer-form';
@@ -33,18 +32,11 @@ export default function BuyPropertyScreen({ push, params }) {
   return (
     <Container data-test-property-transfer>
       <NavBar
+        title="Purchase"
+        titleIcon="transfer"
         showBack={`/${room}/properties`}
         roomCode={room}
-      >
-        <Text
-          upper
-          icon="transfer"
-          color="lighter"
-          data-test-screen-title
-        >
-          Purchase
-        </Text>
-      </NavBar>
+      />
 
       <PropertyTransferForm
         property={property}

--- a/app/src/screens/dashboard.js
+++ b/app/src/screens/dashboard.js
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 
 import { useGame } from '../api';
 import { Container, Section } from '../ui/layout';
-import { Text } from '../ui/typography';
 import Icon from '../ui/icon';
 import Button from '../ui/button';
 import NavBar from '../ui/nav-bar';
@@ -19,6 +18,8 @@ export default function DashboardScreen() {
   return (
     <Container data-test-dashboard>
       <NavBar
+        title={player.name}
+        titleIcon={player.token}
         roomCode={room}
         renderLeft={() => (
           <Button
@@ -29,15 +30,7 @@ export default function DashboardScreen() {
             <Icon name="bank"/>
           </Button>
         )}
-      >
-        <Text
-          color="lighter"
-          icon={player.token}
-          data-test-screen-title
-        >
-          {player.name}
-        </Text>
-      </NavBar>
+      />
 
       <PlayerSummary
         player={player.token}

--- a/app/src/screens/properties.js
+++ b/app/src/screens/properties.js
@@ -5,7 +5,6 @@ import { useGame, useEmit } from '../api';
 import { usePlayer } from '../helpers/hooks';
 
 import { Container } from '../ui/layout';
-import { Text } from '../ui/typography';
 import NavBar from '../ui/nav-bar';
 import Modal from '../ui/modal';
 import PropertySearch from '../game/property-search';
@@ -61,18 +60,11 @@ export default function PropertiesScreen({ push, params }) {
   return (
     <Container data-test-properties-search>
       <NavBar
+        title={player.name ?? 'Properties'}
+        titleIcon={player.token ?? 'bank'}
         showBack={`/${room}${player.token ? '' : '/bank'}`}
         roomCode={room}
-      >
-        <Text
-          upper
-          color="lighter"
-          icon={player.token ?? 'bank'}
-          data-test-screen-title
-        >
-          {player.name ?? 'Properties'}
-        </Text>
-      </NavBar>
+      />
 
       <PropertySearch
         player={player}

--- a/app/src/screens/transfer-property.js
+++ b/app/src/screens/transfer-property.js
@@ -5,7 +5,6 @@ import { useGame, useEmit } from '../api';
 import { usePlayers, useProperty } from '../helpers/hooks';
 
 import { Container } from '../ui/layout';
-import { Text } from '../ui/typography';
 import NavBar from '../ui/nav-bar';
 
 import PropertyTransferForm from '../game/property-transfer-form';
@@ -34,18 +33,11 @@ export default function TransferPropertyScreen({ push, params }) {
   return (
     <Container data-test-property-transfer>
       <NavBar
+        title="Transfer"
+        titleIcon="transfer"
         showBack={`/${room}/properties`}
         roomCode={room}
-      >
-        <Text
-          upper
-          icon="transfer"
-          color="lighter"
-          data-test-screen-title
-        >
-          Transfer
-        </Text>
-      </NavBar>
+      />
 
       <PropertyTransferForm
         players={players}

--- a/app/src/screens/transfer.js
+++ b/app/src/screens/transfer.js
@@ -5,7 +5,6 @@ import { useGame, useEmit } from '../api';
 import { usePlayers } from '../helpers/hooks';
 
 import { Container } from '../ui/layout';
-import { Text } from '../ui/typography';
 import NavBar from '../ui/nav-bar';
 
 import TransferForm from '../game/transfer-form';
@@ -28,18 +27,11 @@ export default function TransferScreen({ push }) {
   return (
     <Container data-test-transfer>
       <NavBar
+        title="Transfer"
+        titleIcon="transfer"
         showBack={`/${room}/bank`}
         roomCode={room}
-      >
-        <Text
-          upper
-          icon="transfer"
-          color="lighter"
-          data-test-screen-title
-        >
-          Transfer
-        </Text>
-      </NavBar>
+      />
 
       <TransferForm
         players={players}

--- a/app/src/ui/nav-bar/nav-bar.js
+++ b/app/src/ui/nav-bar/nav-bar.js
@@ -18,6 +18,8 @@ NavBar.propTypes = {
   roomCode: PropTypes.string,
   renderLeft: PropTypes.func,
   renderRight: PropTypes.func,
+  title: PropTypes.string,
+  titleIcon: PropTypes.string,
   children: PropTypes.node
 };
 
@@ -26,6 +28,8 @@ export default function NavBar({
   roomCode,
   renderLeft,
   renderRight,
+  title,
+  titleIcon,
   children
 }) {
   let { location, goBack } = useRouter();
@@ -44,7 +48,16 @@ export default function NavBar({
         ) : null)}
       </div>
 
-      {children}
+      {children || (
+        <Text
+          upper
+          color="lighter"
+          icon={titleIcon}
+          data-test-nav-title
+        >
+          {title}
+        </Text>
+      )}
 
       <div className={styles['right']}>
         {renderRight ? renderRight() : (!!roomCode && (

--- a/app/test/interactors/game-room.js
+++ b/app/test/interactors/game-room.js
@@ -38,7 +38,7 @@ import AppInteractor from './app';
   roomCode = text('[data-test-room-code]');
   loading = exists('[data-test-spinner]');
 
-  heading = scoped('[data-test-screen-title]', {
+  heading = scoped('[data-test-nav-title]', {
     icon: attribute('[data-test-text-icon]', 'title')
   });
 


### PR DESCRIPTION
## Purpose

Most places that use the NavBar component specify the same text component and properties as the NavBar child. This boilerplate can be reduced by adding a couple properties to the NavBar component and handling the common case as a default.

## Approach

When no children are specified for a NavBar component, the new `title` and `titleIcon` properties are used to default to a common Text component.

### Tests

Only one selector needed to be updated in a single interactor. 😎 