### PR TITLE
More server rules

### DIFF
--- a/server/src/state/player.js
+++ b/server/src/state/player.js
@@ -14,7 +14,8 @@ import {
   isBalanceSufficient,
   isNotNegative,
   isPlayerFound,
-  isTokenAllowed
+  isTokenAllowed,
+  isNotSamePlayer
 } from './rules';
 
 // adds a new player and subtracts the starting balance from the bank
@@ -45,6 +46,7 @@ export function transfer(from, to, amount) {
   return pipe(
     isPlayerFound(from),
     isPlayerFound(to),
+    isNotSamePlayer(from, to),
     isBalanceSufficient(from, amount),
     (to === 'bank'
       ? isBalanceSufficient(to, -amount)
@@ -61,6 +63,7 @@ export function bankrupt(token, beneficiary) {
   return pipe(
     isPlayerFound(token),
     isPlayerFound(beneficiary),
+    isNotSamePlayer(token, beneficiary),
     withOwnProperties(token, properties => pipe(
       properties.map(({ id }) => (
         transferProperty(id, beneficiary)

--- a/server/src/state/player.js
+++ b/server/src/state/player.js
@@ -15,7 +15,8 @@ import {
   isNotNegative,
   isPlayerFound,
   isTokenAllowed,
-  isNotSamePlayer
+  isNotSamePlayer,
+  isNotBankrupt
 } from './rules';
 
 // adds a new player and subtracts the starting balance from the bank
@@ -45,8 +46,9 @@ export function transfer(from, to, amount) {
 
   return pipe(
     isPlayerFound(from),
-    isPlayerFound(to),
     isNotSamePlayer(from, to),
+    isPlayerFound(to),
+    isNotBankrupt(from, to),
     isBalanceSufficient(from, amount),
     (to === 'bank'
       ? isBalanceSufficient(to, -amount)
@@ -62,8 +64,9 @@ export function bankrupt(token, beneficiary) {
 
   return pipe(
     isPlayerFound(token),
-    isPlayerFound(beneficiary),
     isNotSamePlayer(token, beneficiary),
+    isPlayerFound(beneficiary),
+    isNotBankrupt(token, beneficiary),
     withOwnProperties(token, properties => pipe(
       properties.map(({ id }) => (
         transferProperty(id, beneficiary)

--- a/server/src/state/player.js
+++ b/server/src/state/player.js
@@ -11,8 +11,9 @@ import {
   notice
 } from './common';
 import {
-  isBalanceSufficient,
+  isInteger,
   isNotNegative,
+  isBalanceSufficient,
   isPlayerFound,
   isTokenAllowed,
   isNotSamePlayer,
@@ -49,6 +50,7 @@ export function transfer(from, to, amount) {
     isNotSamePlayer(from, to),
     isPlayerFound(to),
     isNotBankrupt(from, to),
+    isInteger(amount),
     isBalanceSufficient(from, amount),
     (to === 'bank'
       ? isBalanceSufficient(to, -amount)

--- a/server/src/state/property.js
+++ b/server/src/state/property.js
@@ -11,8 +11,9 @@ import {
   notice
 } from './common';
 import {
-  isBalanceSufficient,
+  isInteger,
   isNotNegative,
+  isBalanceSufficient,
   isPlayerFound,
   isOwnedBy,
   isNotOwn,
@@ -35,6 +36,7 @@ export function buy(token, property, amount) {
   return pipe(
     isPlayerFound(token),
     isNotBankrupt(token),
+    amount && isInteger(amount),
     isNotNegative(amount),
     isNotOwned(property),
     withProperty(property, ({ price }) => {

--- a/server/src/state/property.js
+++ b/server/src/state/property.js
@@ -26,13 +26,15 @@ import {
   isNotFullyImproved,
   isImprovedEvenly,
   isUnimprovedEvenly,
-  isEnoughBuildings
+  isEnoughBuildings,
+  isNotBankrupt
 } from './rules';
 
 // purchases a property from the bank
 export function buy(token, property, amount) {
   return pipe(
     isPlayerFound(token),
+    isNotBankrupt(token),
     isNotNegative(amount),
     isNotOwned(property),
     withProperty(property, ({ price }) => {
@@ -53,6 +55,7 @@ export function transfer(token, property, owner) {
   return pipe(
     isPlayerFound(token),
     isPlayerFound(owner),
+    isNotBankrupt(token, owner),
     isOwnedBy(property, token),
     isNotOwn(property, owner),
     isNotMortgaged(property),
@@ -157,6 +160,7 @@ export function unmortgage(token, property) {
 export function rent(token, property, dice = 2) {
   return pipe(
     isPlayerFound(token),
+    isNotBankrupt(token),
     isNotOwn(property, token),
     isOwnedBy(property),
     isNotMortgaged(property),

--- a/server/src/state/rules/common.js
+++ b/server/src/state/rules/common.js
@@ -1,0 +1,19 @@
+import { error, withError } from '../../error';
+
+// checks if an amount is an integer to prevent the game getting into weird states
+export function isInteger(amount) {
+  return withError(() => {
+    if (!Number.isInteger(amount)) {
+      throw error('common.amount-type', { amount });
+    }
+  });
+}
+
+// checks if an amount is not negative
+export function isNotNegative(amount) {
+  return withError(() => {
+    if (amount < 0) {
+      throw error('common.negative-amount', { amount });
+    }
+  });
+}

--- a/server/src/state/rules/index.js
+++ b/server/src/state/rules/index.js
@@ -1,2 +1,3 @@
+export * from './common';
 export * from './player';
 export * from './property';

--- a/server/src/state/rules/player.js
+++ b/server/src/state/rules/player.js
@@ -11,15 +11,6 @@ export function isBalanceSufficient(token, amount) {
   });
 }
 
-// checks if an amount is not negative
-export function isNotNegative(amount) {
-  return withError(() => {
-    if (amount < 0) {
-      throw error('common.negative-amount', { amount });
-    }
-  });
-}
-
 // checks if a player exists in the game
 export function isPlayerFound(token) {
   return withError(({ players }) => {

--- a/server/src/state/rules/player.js
+++ b/server/src/state/rules/player.js
@@ -48,3 +48,14 @@ export function isNotSamePlayer(token, other) {
     }
   });
 }
+
+// checks if a player and optionally another is not bankrupt
+export function isNotBankrupt(token, other) {
+  return withError(({ players }) => {
+    if (token !== 'bank' && players[token].bankrupt) {
+      throw error('player.bankrupt');
+    } else if (other && other !== 'bank' && players[other].bankrupt) {
+      throw error('player.other-bankrupt', { other });
+    }
+  });
+}

--- a/server/src/state/rules/player.js
+++ b/server/src/state/rules/player.js
@@ -39,3 +39,12 @@ export function isTokenAllowed(token) {
     }
   });
 }
+
+// checks if a player is trying to perform an action with themselves
+export function isNotSamePlayer(token, other) {
+  return withError(() => {
+    if (token === other) {
+      throw error('player.self');
+    }
+  });
+}

--- a/server/test/acceptance/buying-properties.test.js
+++ b/server/test/acceptance/buying-properties.test.js
@@ -89,6 +89,12 @@ describe('buying properties', () => {
       .rejects.toThrow('Amount must not be negative');
   });
 
+  it('responds with an error when bankrupt', async () => {
+    await socket1.send('player:bankrupt', 'bank');
+    await expect(socket1.send('property:buy', 'connecticut-avenue'))
+      .rejects.toThrow('Unable to do that while bankrupt');
+  });
+
   it('receives an error when the property is already owned', async () => {
     await expect(socket2.send('property:buy', 'oriental-avenue'))
       .rejects.toThrow('Oriental Avenue is owned by PLAYER 1');

--- a/server/test/acceptance/buying-properties.test.js
+++ b/server/test/acceptance/buying-properties.test.js
@@ -84,6 +84,11 @@ describe('buying properties', () => {
     expect(game).toHaveProperty('notice.message', 'PLAYER 1 purchased Baltic Avenue');
   });
 
+  it('responds with an error with a non-integer', async () => {
+    await expect(socket1.send('property:buy', 'boardwalk', 'I.O.U.'))
+      .rejects.toThrow('Amount must be an integer');
+  });
+
   it('receives an error when specifying a negative amount', async () => {
     await expect(socket2.send('property:buy', 'baltic-avenue', -10))
       .rejects.toThrow('Amount must not be negative');

--- a/server/test/acceptance/claiming-bankruptcy.test.js
+++ b/server/test/acceptance/claiming-bankruptcy.test.js
@@ -86,4 +86,9 @@ describe('claiming bankruptcy', () => {
     await expect(socket1.send('player:bankrupt', 'thimble'))
       .rejects.toThrow('Cannot find player with token "thimble"');
   });
+
+  it('responds with an error when benefiting yourself', async () => {
+    await expect(socket1.send('player:bankrupt', 'top-hat'))
+      .rejects.toThrow("You can't play with yourself");
+  });
 });

--- a/server/test/acceptance/claiming-bankruptcy.test.js
+++ b/server/test/acceptance/claiming-bankruptcy.test.js
@@ -87,6 +87,18 @@ describe('claiming bankruptcy', () => {
       .rejects.toThrow('Cannot find player with token "thimble"');
   });
 
+  it('responds with an error when already bankrupt', async () => {
+    await socket1.send('player:bankrupt', 'bank');
+    await expect(socket1.send('player:bankrupt', 'automobile'))
+      .rejects.toThrow('Unable to do that while bankrupt');
+  });
+
+  it('responds with an error when the beneficiary is bankrupt', async () => {
+    await socket2.send('player:bankrupt', 'bank');
+    await expect(socket1.send('player:bankrupt', 'automobile'))
+      .rejects.toThrow('PLAYER 2 is bankrupt');
+  });
+
   it('responds with an error when benefiting yourself', async () => {
     await expect(socket1.send('player:bankrupt', 'top-hat'))
       .rejects.toThrow("You can't play with yourself");

--- a/server/test/acceptance/renting-properties.test.js
+++ b/server/test/acceptance/renting-properties.test.js
@@ -161,6 +161,12 @@ describe('renting properties', () => {
       .rejects.toThrow('Boardwalk is unowned');
   });
 
+  it('responds with an error when bankrupt', async () => {
+    await socket1.send('player:bankrupt', 'bank');
+    await expect(socket1.send('property:rent', 'indiana-avenue'))
+      .rejects.toThrow('Unable to do that while bankrupt');
+  });
+
   it('receives an error when the property is mortgaged', async () => {
     await expect(socket2.send('property:rent', 'states-avenue'))
       .rejects.toThrow('States Avenue is mortgaged');

--- a/server/test/acceptance/transferring-balances.test.js
+++ b/server/test/acceptance/transferring-balances.test.js
@@ -78,6 +78,11 @@ describe('transferring balances', () => {
     expect(game).toHaveProperty('notice.message', 'PLAYER 1 paid the bank $100');
   });
 
+  it('responds with an error with a non-integer', async () => {
+    await expect(socket1.send('player:transfer', 'bank', -Infinity))
+      .rejects.toThrow('Amount must be an integer');
+  });
+
   it('responds with an error when the bank is insufficient', async () => {
     await expect(socket1.send('player:transfer', 'bank', -11000))
       .rejects.toThrow('Bank funds are insufficient');

--- a/server/test/acceptance/transferring-balances.test.js
+++ b/server/test/acceptance/transferring-balances.test.js
@@ -83,6 +83,11 @@ describe('transferring balances', () => {
       .rejects.toThrow('Bank funds are insufficient');
   });
 
+  it('responds with an error when transferring to yourself', async () => {
+    await expect(socket1.send('player:transfer', 'top-hat', 11000))
+      .rejects.toThrow("You can't play with yourself");
+  });
+
   it('responds with an error when the player has an insufficient balance', async () => {
     await expect(socket1.send('player:transfer', 'automobile', 2000))
       .rejects.toThrow('Insufficient balance');

--- a/server/test/acceptance/transferring-balances.test.js
+++ b/server/test/acceptance/transferring-balances.test.js
@@ -88,6 +88,18 @@ describe('transferring balances', () => {
       .rejects.toThrow("You can't play with yourself");
   });
 
+  it('responds with an error when bankrupt', async () => {
+    await socket1.send('player:bankrupt', 'bank');
+    await expect(socket1.send('player:transfer', 'automobile', 100))
+      .rejects.toThrow('Unable to do that while bankrupt');
+  });
+
+  it('responds with an error when the other player is bankrupt', async () => {
+    await socket2.send('player:bankrupt', 'bank');
+    await expect(socket1.send('player:transfer', 'automobile', 100))
+      .rejects.toThrow('PLAYER 2 is bankrupt');
+  });
+
   it('responds with an error when the player has an insufficient balance', async () => {
     await expect(socket1.send('player:transfer', 'automobile', 2000))
       .rejects.toThrow('Insufficient balance');

--- a/server/test/acceptance/transferring-properties.test.js
+++ b/server/test/acceptance/transferring-properties.test.js
@@ -82,6 +82,18 @@ describe('transferring properties', () => {
       .rejects.toThrow('You own Connecticut Avenue');
   });
 
+  it('responds with an error when bankrupt', async () => {
+    await socket1.send('player:bankrupt', 'bank');
+    await expect(socket1.send('property:transfer', 'connecticut-avenue', 'automobile'))
+      .rejects.toThrow('Unable to do that while bankrupt');
+  });
+
+  it('responds with an error when the other player is bankrupt', async () => {
+    await socket2.send('player:bankrupt', 'bank');
+    await expect(socket1.send('property:transfer', 'connecticut-avenue', 'automobile'))
+      .rejects.toThrow('PLAYER 2 is bankrupt');
+  });
+
   it('responds with an error when the property is mortgaged', async () => {
     await expect(socket1.send('property:transfer', 'baltic-avenue', 'automobile'))
       .rejects.toThrow('Baltic Avenue is mortgaged');

--- a/server/themes/classic/messages.yml
+++ b/server/themes/classic/messages.yml
@@ -34,6 +34,8 @@ error:
     denied: 'Sorry, your friends hate you'
     empty-room: 'Nobody is in the room'
     balance: 'Insufficient balance'
+    bankrupt: 'Unable to do that while bankrupt'
+    other-bankrupt: '{{other.name}} is bankrupt'
     veto-denied: 'Your friends did not agree to veto'
 
   property:

--- a/server/themes/classic/messages.yml
+++ b/server/themes/classic/messages.yml
@@ -25,6 +25,7 @@ error:
     event-not-found: 'No matching event found'
 
   player:
+    self: "You can't play with yourself"
     playing: 'Player already joined'
     missing-token: 'Invalid token'
     used-token: 'Token already in use'

--- a/server/themes/classic/messages.yml
+++ b/server/themes/classic/messages.yml
@@ -22,6 +22,7 @@ error:
   common:
     bank-low: 'Bank funds are insufficient'
     negative-amount: 'Amount must not be negative'
+    amount-type: 'Amount must be an integer'
     event-not-found: 'No matching event found'
 
   player:


### PR DESCRIPTION
## Purpose

A few server rules were added to prevent game issues.

- You shouldn't be able to perform actions with yourself that require other players.
- You shouldn't be able to perform actions when bankrupt or when other players are bankrupt.
- Amounts could possibly be non-integers which might put the game into a weird state.

## Approach

1. Create rules, including messages
2. Add rules to relevant state actions
3. Write tests for said rules