### PR TITLE
Claiming bankruptcy

### DIFF
--- a/app/src/game/bankrupt-form.js
+++ b/app/src/game/bankrupt-form.js
@@ -1,0 +1,56 @@
+import React, { useCallback, useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+import { Container, Section } from '../ui/layout';
+import Button from '../ui/button';
+
+import PlayerSelect from './player-select';
+
+BankruptForm.propTypes = {
+  players: PropTypes.array,
+  loading: PropTypes.bool.isRequired,
+  onSubmit: PropTypes.func.isRequired
+};
+
+export default function BankruptForm({
+  players,
+  loading,
+  onSubmit
+}) {
+  let beneficiaries = useMemo(() => [{ name: 'Bank', token: 'bank' }].concat(players), [players]);
+  let [ beneficiary, setBeneficiary ] = useState(beneficiaries[0]);
+
+  let handleSubmit = useCallback(e => {
+    e.preventDefault();
+    onSubmit(beneficiary);
+  }, [onSubmit, beneficiary]);
+
+  return (
+    <Container
+      tagName="form"
+      onSubmit={handleSubmit}
+      data-test-property-transfer-form
+    >
+      <Section collapse justify="center" align="center">
+        <PlayerSelect
+          label="Beneficiary:"
+          players={beneficiaries}
+          selected={beneficiary}
+          onSelect={setBeneficiary}
+        />
+      </Section>
+
+      <Section flex="none">
+        <Button
+          block
+          type="submit"
+          style="alert"
+          loading={loading}
+          disabled={loading}
+        >
+          Claim Bankruptcy
+        </Button>
+      </Section>
+    </Container>
+  );
+}

--- a/app/src/game/player-card/player-card.css
+++ b/app/src/game/player-card/player-card.css
@@ -6,3 +6,7 @@
   justify-content: space-between;
   margin-bottom: var(--pad-med);
 }
+
+.bankrupt {
+  opacity: 0.6;
+}

--- a/app/src/game/player-card/player-card.js
+++ b/app/src/game/player-card/player-card.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 
 import { useGame } from '../../api';
 import { usePlayer, useProperties } from '../../helpers/hooks';
@@ -11,23 +12,31 @@ import Card from '../../ui/card';
 
 import styles from './player-card.css';
 
+const cx = classNames.bind(styles);
+
 PlayerCard.propTypes = {
   player: PropTypes.string.isRequired,
 };
 
 export default function PlayerCard({ player }) {
-  let { token, name, balance } = usePlayer(player);
+  let { token, name, balance, bankrupt } = usePlayer(player);
   let properties = useProperties(player);
   let { room } = useGame();
 
   return (
-    <Card linkTo={`/${room}/${token}/properties`}>
+    <Card
+      className={cx({ bankrupt })}
+      linkTo={!bankrupt && properties.length && `/${room}/${token}/properties`}
+    >
       <div className={styles.header}>
         <Text color="light" icon={token} data-test-player-name>{name}</Text>
         <Currency color="secondary" value={balance} data-test-player-balance/>
       </div>
 
-      <PropertiesList properties={properties}/>
+      <PropertiesList
+        properties={properties}
+        bankrupt={bankrupt}
+      />
     </Card>
   );
 }

--- a/app/src/game/player-select/player-select.css
+++ b/app/src/game/player-select/player-select.css
@@ -40,6 +40,10 @@
     margin-bottom: var(--pad-xs);
   }
 
+  &.is-disabled {
+    color: var(--color-bg-light);
+  }
+
   &.is-selected {
     color: var(--color-text-lighter);
   }

--- a/app/src/game/player-select/player-select.js
+++ b/app/src/game/player-select/player-select.js
@@ -64,8 +64,11 @@ export default function PlayerSelect({
         onSelect={onSelect}
         selected={selectedIndex}
         disabled={disabledIndices}
-        renderItem={(player, { selected }) => (
-          <div className={cx('token', { 'is-selected': selected })}>
+        renderItem={(player, { selected, disabled }) => (
+          <div className={cx('token', {
+            'is-selected': selected,
+            'is-disabled': disabled
+          })}>
             <Icon name={player.token}/>
             <Text upper sm>{player.name}</Text>
           </div>

--- a/app/src/game/player-select/player-select.js
+++ b/app/src/game/player-select/player-select.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './player-select.css';
@@ -27,6 +27,16 @@ export default function PlayerSelect({
   selected,
   onSelect,
 }) {
+  let selectedIndex = useMemo(() => (
+    selected ? players.indexOf(selected) : 0
+  ), [selected, players.length]);
+
+  let disabledIndices = useMemo(() => (
+    players.reduce((d, p, i) => (
+      p.bankrupt === true ? d.concat(i) : d
+    ), [])
+  ), [players]);
+
   return (
     <div
       className={styles.root}
@@ -52,7 +62,8 @@ export default function PlayerSelect({
         data={players}
         itemIdKey="token"
         onSelect={onSelect}
-        selected={selected ? players.indexOf(selected) : 0}
+        selected={selectedIndex}
+        disabled={disabledIndices}
         renderItem={(player, { selected }) => (
           <div className={cx('token', { 'is-selected': selected })}>
             <Icon name={player.token}/>

--- a/app/src/game/player-summary/player-summary.css
+++ b/app/src/game/player-summary/player-summary.css
@@ -3,3 +3,8 @@
 .balance {
   margin-bottom: var(--pad-lg);
 }
+
+.bankrupt {
+  margin: var(--pad-xxl) 0;
+  opacity: 0.2;
+}

--- a/app/src/game/player-summary/player-summary.js
+++ b/app/src/game/player-summary/player-summary.js
@@ -5,7 +5,7 @@ import { useGame } from '../../api';
 import { usePlayer, useProperties } from '../../helpers/hooks';
 
 import { Section } from '../../ui/layout';
-import Currency from '../../ui/typography/currency';
+import { Text, Currency } from '../../ui/typography';
 import Link from '../../ui/link';
 import PropertiesList from '../properties-list';
 
@@ -16,26 +16,37 @@ PlayerSummary.propTypes = {
 };
 
 export default function PlayerSummary({ player }) {
-  let { room } = useGame();
-  let { balance } = usePlayer(player);
+  let { balance, bankrupt } = usePlayer(player);
   let properties = useProperties(player);
+  let { room } = useGame();
 
   return (
     <Section flex="none" collapse data-test-summary>
-      <Currency
-        value={balance}
-        color="secondary"
-        className={styles.balance}
-        data-test-player-balance
-        center
-        xl
-      />
+      {bankrupt ? (
+        <Text
+          className={styles.bankrupt}
+          center
+          upper
+          xl
+        >
+          Bankrupt
+        </Text>
+      ) : (
+        <>
+          <Currency
+            value={balance}
+            color="secondary"
+            className={styles.balance}
+            data-test-player-balance
+            center
+            xl
+          />
 
-      <Link to={`/${room}/${player}/properties`}>
-        <PropertiesList
-          properties={properties}
-        />
-      </Link>
+          <Link to={`/${room}/${player}/properties`}>
+            <PropertiesList properties={properties}/>
+          </Link>
+        </>
+      )}
     </Section>
   );
 }

--- a/app/src/game/player-summary/player-summary.js
+++ b/app/src/game/player-summary/player-summary.js
@@ -24,6 +24,7 @@ export default function PlayerSummary({ player }) {
     <Section flex="none" collapse data-test-summary>
       {bankrupt ? (
         <Text
+          data-test-summary-bankrupt
           className={styles.bankrupt}
           center
           upper

--- a/app/src/game/properties-list/properties-list.js
+++ b/app/src/game/properties-list/properties-list.js
@@ -16,10 +16,11 @@ PropertiesList.propTypes = {
   properties: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     group: PropTypes.string.isRequired
-  })).isRequired
+  })).isRequired,
+  bankrupt: PropTypes.bool
 };
 
-export default function PropertiesList({ properties }) {
+export default function PropertiesList({ properties, bankrupt }) {
   let { groupColors } = useConfig();
   let empty = properties.length === 0;
 
@@ -35,7 +36,7 @@ export default function PropertiesList({ properties }) {
     <div className={cx('root', { 'is-empty': empty })}>
       {empty ? (
         <Text upper className={styles.message}>
-          No Owned Properties
+          {bankrupt ? 'Bankrupt' : 'No Owned Properties'}
         </Text>
       ) : (
         groups.map(group => (

--- a/app/src/game/properties-list/properties-list.js
+++ b/app/src/game/properties-list/properties-list.js
@@ -33,14 +33,17 @@ export default function PropertiesList({ properties, bankrupt }) {
   ), [groupColors, properties]);
 
   return (
-    <div className={cx('root', { 'is-empty': empty })}>
+    <div
+      className={cx('root', { 'is-empty': empty })}
+      data-test-properties-list
+    >
       {empty ? (
         <Text upper className={styles.message}>
           {bankrupt ? 'Bankrupt' : 'No Owned Properties'}
         </Text>
       ) : (
         groups.map(group => (
-          <div key={group.name} className={styles.group} data-test-property-list-group>
+          <div key={group.name} className={styles.group} data-test-properties-list-group>
             {group.properties.map(property => (
               <div key={property.id} className={styles.property} data-test-property={property.id}>
                 {!group.color ? (

--- a/app/src/game/property-search/property-search.js
+++ b/app/src/game/property-search/property-search.js
@@ -16,6 +16,7 @@ PropertySearch.propTypes = {
   player: PropTypes.shape({
     token: PropTypes.string
   }),
+  hideActions: PropTypes.bool,
   onPurchase: PropTypes.func,
   onRent: PropTypes.func,
   onImprove: PropTypes.func,
@@ -26,6 +27,7 @@ PropertySearch.propTypes = {
 
 export default function PropertySearch({
   player,
+  hideActions,
   onPurchase,
   onRent,
   onImprove,
@@ -102,6 +104,7 @@ export default function PropertySearch({
               onUnimprove={onUnimprove}
               onMortgage={onMortgage}
               onUnmortgage={onUnmortgage}
+              hideActions={hideActions}
               showDetails
             />
           ) : (

--- a/app/src/game/property/property.js
+++ b/app/src/game/property/property.js
@@ -27,6 +27,7 @@ Property.propTypes = {
     owner: PropTypes.string.isRequired
   }).isRequired,
   showDetails: PropTypes.bool,
+  hideActions: PropTypes.bool,
   onClick: PropTypes.func,
   onPurchase: PropTypes.func,
   onRent: PropTypes.func,
@@ -51,6 +52,7 @@ export default function Property({
     owner
   },
   showDetails,
+  hideActions,
   onClick,
   onPurchase,
   onRent,
@@ -250,90 +252,92 @@ export default function Property({
         </dl>
       </div>
 
-      <div className={styles.actions}>
-        {owner === 'bank' && onPurchase && (
-          <>
+      {!hideActions && (
+        <div className={styles.actions}>
+          {owner === 'bank' && onPurchase && (
+            <>
+              <Button
+                block
+                hollow
+                style="primary"
+                onClick={() => onPurchase(id, price)}
+                data-test-property-buy-btn
+              >
+                Buy for &zwj;
+                <Currency value={price} data-test-property-price/>
+              </Button>
+
+              <Button
+                block
+                hollow
+                className={styles['buy-other']}
+                linkTo={`/${room}/${id}/buy`}
+                data-test-property-buy-other-btn
+              >
+                enter other amount
+              </Button>
+            </>
+          )}
+          {owner !== 'bank' && !isOwn && !mortgaged && onRent && (
+            <Button
+              block
+              hollow
+              style="alert"
+              onClick={() => onRent(id, isUtility)}
+              data-test-property-rent-btn
+            >
+              Pay Rent &zwj;
+              {isUtility ? (
+                <>(x{rentAmount})</>
+              ) : (
+                <>(<Currency value={rentAmount} data-test-property-rent/>)</>
+              )}
+            </Button>
+          )}
+          {isOwn && mortgaged && onUnmortgage && (
             <Button
               block
               hollow
               style="primary"
-              onClick={() => onPurchase(id, price)}
-              data-test-property-buy-btn
+              onClick={() => onUnmortgage(id)}
+              data-test-property-unmortgage-btn
             >
-              Buy for &zwj;
-              <Currency value={price} data-test-property-price/>
+              Unmortgage
+              (<Currency value={mortgageValue + (mortgageValue * interestRate)} data-test-property-unmortgage/>)
             </Button>
-
+          )}
+          {isOwn && !mortgaged && !buildings && onMortgage && (
             <Button
-              block
               hollow
-              className={styles['buy-other']}
-              linkTo={`/${room}/${id}/buy`}
-              data-test-property-buy-other-btn
+              style="alert"
+              onClick={() => onMortgage(id)}
+              data-test-property-mortgage-btn
             >
-              enter other amount
+              Mortgage
             </Button>
-          </>
-        )}
-        {owner !== 'bank' && !isOwn && !mortgaged && onRent && (
-          <Button
-            block
-            hollow
-            style="alert"
-            onClick={() => onRent(id, isUtility)}
-            data-test-property-rent-btn
-          >
-            Pay Rent &zwj;
-            {isUtility ? (
-              <>(x{rentAmount})</>
-            ) : (
-              <>(<Currency value={rentAmount} data-test-property-rent/>)</>
-            )}
-          </Button>
-        )}
-        {isOwn && mortgaged && onUnmortgage && (
-          <Button
-            block
-            hollow
-            style="primary"
-            onClick={() => onUnmortgage(id)}
-            data-test-property-unmortgage-btn
-          >
-            Unmortgage
-            (<Currency value={mortgageValue + (mortgageValue * interestRate)} data-test-property-unmortgage/>)
-          </Button>
-        )}
-        {isOwn && !mortgaged && !buildings && onMortgage && (
-          <Button
-            hollow
-            style="alert"
-            onClick={() => onMortgage(id)}
-            data-test-property-mortgage-btn
-          >
-            Mortgage
-          </Button>
-        )}
-        {isOwn && !isRailroad && !isUtility && buildings > 0 && onUnimprove && (
-          <Button
-            hollow
-            style="alert"
-            onClick={() => onUnimprove(id)}
-            data-test-property-unimprove-btn
-          >
-            Unimprove
-          </Button>
-        )}
-        {isOwn && !isRailroad && !isUtility && monopoly && !mortgaged && buildings < 5 && onImprove && (
-          <Button
-            hollow
-            style="secondary"
-            onClick={() => onImprove(id)}
-            data-test-property-improve-btn
-          >
-            Improve
-          </Button>
-        )}
-      </div>
+          )}
+          {isOwn && !isRailroad && !isUtility && buildings > 0 && onUnimprove && (
+            <Button
+              hollow
+              style="alert"
+              onClick={() => onUnimprove(id)}
+              data-test-property-unimprove-btn
+            >
+              Unimprove
+            </Button>
+          )}
+          {isOwn && !isRailroad && !isUtility && monopoly && !mortgaged && buildings < 5 && onImprove && (
+            <Button
+              hollow
+              style="secondary"
+              onClick={() => onImprove(id)}
+              data-test-property-improve-btn
+            >
+              Improve
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/screens/bank.js
+++ b/app/src/screens/bank.js
@@ -2,7 +2,7 @@ import React, { useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { useGame, useEmit } from '../api';
-import { usePlayers } from '../helpers/hooks';
+import { usePlayer, usePlayers } from '../helpers/hooks';
 
 import { Container, Section } from '../ui/layout';
 import { Text } from '../ui/typography';
@@ -19,6 +19,7 @@ BankScreen.propTypes = {
 export default function BankScreen({ push }) {
   let { room, player } = useGame();
   let players = usePlayers({ exclude: [player.token] });
+  let { bankrupt: isBankrupt } = usePlayer(player.token);
   let [ showBankruptForm, toggleBankruptForm ] = useState(false);
   let [ bankrupt, bankruptResponse ] = useEmit('player:bankrupt');
 
@@ -39,25 +40,27 @@ export default function BankScreen({ push }) {
         roomCode={room}
       />
 
-      <Section>
-        <Card linkTo={`/${room}/transfer`}>
-          <Text upper icon="transfer">
-            Transfer
-          </Text>
-        </Card>
+      {!isBankrupt && (
+        <Section>
+          <Card linkTo={`/${room}/transfer`}>
+            <Text upper icon="transfer">
+              Transfer
+            </Text>
+          </Card>
 
-        <Card linkTo={`/${room}/properties`}>
-          <Text upper icon="bank">
-            Properties
-          </Text>
-        </Card>
+          <Card linkTo={`/${room}/properties`}>
+            <Text upper icon="bank">
+              Properties
+            </Text>
+          </Card>
 
-        <Card onClick={() => toggleBankruptForm(true)}>
-          <Text upper icon="currency">
-            Bankrupt
-          </Text>
-        </Card>
-      </Section>
+          <Card onClick={() => toggleBankruptForm(true)}>
+            <Text upper icon="currency">
+              Bankrupt
+            </Text>
+          </Card>
+        </Section>
+      )}
 
       {showBankruptForm && (
         <Modal

--- a/app/src/screens/bank.js
+++ b/app/src/screens/bank.js
@@ -1,14 +1,34 @@
-import React from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 
-import { useGame } from '../api';
+import { useGame, useEmit } from '../api';
+import { usePlayers } from '../helpers/hooks';
 
 import { Container, Section } from '../ui/layout';
 import { Text } from '../ui/typography';
 import NavBar from '../ui/nav-bar';
 import Card from '../ui/card';
+import Modal from '../ui/modal';
 
-export default function BankScreen() {
-  let { room } = useGame();
+import BankruptForm from '../game/bankrupt-form';
+
+BankScreen.propTypes = {
+  push: PropTypes.func.isRequired
+};
+
+export default function BankScreen({ push }) {
+  let { room, player } = useGame();
+  let players = usePlayers({ exclude: [player.token] });
+  let [ showBankruptForm, toggleBankruptForm ] = useState(false);
+  let [ bankrupt, bankruptResponse ] = useEmit('player:bankrupt');
+
+  let handleBankrupt = useCallback(beneficiary => {
+    if (!bankruptResponse.pending) bankrupt(beneficiary.token);
+  }, [bankruptResponse.pending, bankrupt]);
+
+  useEffect(() => {
+    if (bankruptResponse.ok) push(`/${room}`);
+  }, [bankruptResponse.ok]);
 
   return (
     <Container data-test-bank>
@@ -31,7 +51,27 @@ export default function BankScreen() {
             Properties
           </Text>
         </Card>
+
+        <Card onClick={() => toggleBankruptForm(true)}>
+          <Text upper icon="currency">
+            Bankrupt
+          </Text>
+        </Card>
       </Section>
+
+      {showBankruptForm && (
+        <Modal
+          title="Bankrupt"
+          titleIcon="currency"
+          onClose={() => toggleBankruptForm(false)}
+        >
+          <BankruptForm
+            players={players}
+            loading={bankruptResponse.pending}
+            onSubmit={handleBankrupt}
+          />
+        </Modal>
+      )}
     </Container>
   );
 }

--- a/app/src/screens/dashboard.js
+++ b/app/src/screens/dashboard.js
@@ -8,13 +8,21 @@ import NavBar from '../ui/nav-bar';
 import PlayerSummary from '../game/player-summary';
 import PlayerCard from '../game/player-card';
 
+function playerSort(players) {
+  return (a, b) => {
+    if (players[a].bankrupt) return 1;
+    if (players[b].bankrupt) return -1;
+    return players.all.indexOf(a) - players.all.indexOf(b);
+  };
+}
+
 export default function DashboardScreen() {
   let { room, player, players } = useGame();
 
   players = useMemo(() => (
     players.all
       .filter(token => token !== player.token)
-      .sort((_, token) => players[token].bankrupt ? -1 : 0)
+      .sort(playerSort(players))
   ), [player.token, players.all]);
 
   return (

--- a/app/src/screens/dashboard.js
+++ b/app/src/screens/dashboard.js
@@ -12,7 +12,9 @@ export default function DashboardScreen() {
   let { room, player, players } = useGame();
 
   players = useMemo(() => (
-    players.all.filter(token => token !== player.token)
+    players.all
+      .filter(token => token !== player.token)
+      .sort((_, token) => players[token].bankrupt ? -1 : 0)
   ), [player.token, players.all]);
 
   return (

--- a/app/src/screens/find-room.js
+++ b/app/src/screens/find-room.js
@@ -22,8 +22,8 @@ export default function FindRoomScreen({ push }) {
     if (!pending) connect(room.toLowerCase());
   }, [pending]);
 
-  useEffect(() => room && disconnect(), []);
-  useEffect(() => { ok && push(`/${room}/join`); }, [ok]);
+  useEffect(() => void(room && disconnect()), []);
+  useEffect(() => void(ok && push(`/${room}/join`)), [ok]);
 
   return (
     <Container data-test-find-room>

--- a/app/src/screens/properties.js
+++ b/app/src/screens/properties.js
@@ -25,8 +25,9 @@ export default function PropertiesScreen({ push, params }) {
   let [ mortgageProperty, mortgageResponse ] = useEmit('property:mortgage');
   let [ unmortgageProperty, unmortgageResponse ] = useEmit('property:unmortgage');
   let [ showDiceForm, toggleDiceForm ] = useState(null);
+  let { room, player: { token: currentPlayer } } = useGame();
+  let { bankrupt: hideActions } = usePlayer(currentPlayer);
   let player = usePlayer(params.token);
-  let { room } = useGame();
 
   let handlePurchase = useCallback((id, amount) => {
     if (!buyResponse.pending) buyProperty(id, amount);
@@ -74,6 +75,7 @@ export default function PropertiesScreen({ push, params }) {
         onUnimprove={handleUnimprove}
         onMortgage={handleMortgage}
         onUnmortgage={handleUnmortgage}
+        hideActions={hideActions}
       />
 
       {showDiceForm && (

--- a/app/src/screens/transfer.js
+++ b/app/src/screens/transfer.js
@@ -22,7 +22,7 @@ export default function TransferScreen({ push }) {
     if (!pending) transfer(token, amount);
   }, [pending]);
 
-  useEffect(() => ok && push(`/${room}`), [ok]);
+  useEffect(() => void(ok && push(`/${room}`)), [ok]);
 
   return (
     <Container data-test-transfer>

--- a/app/src/screens/welcome.js
+++ b/app/src/screens/welcome.js
@@ -18,8 +18,8 @@ export default function WelcomeScreen({ push }) {
   let [ newGame, { pending, ok, data } ] = useEmit('room:create');
   let handleNewGame = useCallback(() => !pending && newGame(), [pending]);
 
-  useEffect(() => room && disconnect(), []);
-  useEffect(() => ok && push(`/${data[0].room}/join`), [ok]);
+  useEffect(() => void(room && disconnect()), []);
+  useEffect(() => void(ok && push(`/${data[0].room}/join`)), [ok]);
 
   return (
     <Container data-test-welcome>

--- a/app/src/ui/card/card.css
+++ b/app/src/ui/card/card.css
@@ -6,8 +6,13 @@
   margin-bottom: var(--pad-med);
   padding: var(--pad-med);
   background-color: var(--color-bg-dark);
+  line-height: 1;
 
   &:last-child {
     margin-bottom: 0;
+  }
+
+  &.is-clickable {
+    cursor: pointer;
   }
 }

--- a/app/src/ui/card/card.js
+++ b/app/src/ui/card/card.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 
 import Link from '../link';
 import styles from './card.css';
+
+const cx = classNames.bind(styles);
 
 Card.propTypes = {
   linkTo: PropTypes.any,
@@ -17,12 +20,14 @@ export default function Card({
   className,
   children
 }) {
-  let Component = linkTo ? Link : 'button';
+  let Component = linkTo ? Link : 'div';
   let props = linkTo ? { to: linkTo } : { onClick };
 
   return (
     <Component
-      className={[styles.root, className].filter(Boolean).join(' ')}
+      className={cx('root', {
+        'is-clickable': !!(linkTo || onClick)
+      }, className)}
       data-test-card
       {...props}
     >

--- a/app/src/ui/card/card.js
+++ b/app/src/ui/card/card.js
@@ -5,7 +5,7 @@ import Link from '../link';
 import styles from './card.css';
 
 Card.propTypes = {
-  linkTo: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  linkTo: PropTypes.any,
   onClick: PropTypes.func,
   className: PropTypes.string,
   children: PropTypes.node.isRequired,

--- a/app/src/ui/card/card.js
+++ b/app/src/ui/card/card.js
@@ -5,31 +5,28 @@ import Link from '../link';
 import styles from './card.css';
 
 Card.propTypes = {
-  linkTo: PropTypes.string,
+  linkTo: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onClick: PropTypes.func,
-  children: PropTypes.node.isRequired
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
 };
 
 export default function Card({
   linkTo,
   onClick,
+  className,
   children
 }) {
-  return linkTo ? (
-    <Link
-      to={linkTo}
-      className={styles.root}
+  let Component = linkTo ? Link : 'button';
+  let props = linkTo ? { to: linkTo } : { onClick };
+
+  return (
+    <Component
+      className={[styles.root, className].filter(Boolean).join(' ')}
       data-test-card
+      {...props}
     >
       {children}
-    </Link>
-  ) : (
-    <button
-      onClick={onClick}
-      className={styles.root}
-      data-test-card
-    >
-      {children}
-    </button>
+    </Component>
   );
 }

--- a/app/src/ui/card/card.js
+++ b/app/src/ui/card/card.js
@@ -5,15 +5,17 @@ import Link from '../link';
 import styles from './card.css';
 
 Card.propTypes = {
-  linkTo: PropTypes.string.isRequired,
+  linkTo: PropTypes.string,
+  onClick: PropTypes.func,
   children: PropTypes.node.isRequired
 };
 
 export default function Card({
   linkTo,
+  onClick,
   children
 }) {
-  return (
+  return linkTo ? (
     <Link
       to={linkTo}
       className={styles.root}
@@ -21,5 +23,13 @@ export default function Card({
     >
       {children}
     </Link>
+  ) : (
+    <button
+      onClick={onClick}
+      className={styles.root}
+      data-test-card
+    >
+      {children}
+    </button>
   );
 }

--- a/app/src/ui/modal/modal.css
+++ b/app/src/ui/modal/modal.css
@@ -9,7 +9,7 @@
   transform: translate(-50%, -50%);
   box-shadow: var(--shadow-lg);
   width: 22rem;
-  height: 14rem;
+  min-height: 14rem;
 }
 
 .modal-backdrop {

--- a/app/test/acceptance/bank.test.js
+++ b/app/test/acceptance/bank.test.js
@@ -98,7 +98,7 @@ describe('BankScreen', () => {
       .percySnapshot('after bankruptcy');
   });
 
-  it('can choose another player as the beneficiary', async () => {
+  it('can choose another player as the bankrupt beneficiary', async () => {
     await bank
       .links(2).click()
       .bankrupt.players('automobile').click()
@@ -109,5 +109,17 @@ describe('BankScreen', () => {
       .assert.toast.message('PLAYER 2 bankrupt YOU');
     await bank
       .percySnapshot('after benficiary bankruptcy');
+  });
+
+  it('does not show actions for bankrupt players', async function() {
+    await this.grm.mock({
+      room: 't35tt',
+      players: [{ token: 'top-hat', bankrupt: true }]
+    });
+
+    await bank
+      .assert.exists()
+      .assert.links().count(0)
+      .percySnapshot('as bankrupt player');
   });
 });

--- a/app/test/acceptance/bank.test.js
+++ b/app/test/acceptance/bank.test.js
@@ -122,4 +122,16 @@ describe('BankScreen', () => {
       .assert.links().count(0)
       .percySnapshot('as bankrupt player');
   });
+
+  it('disables bankrupt players when choosing a bankrupt beneficiary', async function() {
+    await this.grm.mock({
+      room: 't35tt',
+      players: [{ token: 'automobile', bankrupt: true }]
+    });
+
+    await bank
+      .links(2).click()
+      .assert.bankrupt.players('automobile').disabled()
+      .percySnapshot('bankrupt modal with bankrupt players');
+  });
 });

--- a/app/test/acceptance/dashboard.test.js
+++ b/app/test/acceptance/dashboard.test.js
@@ -11,7 +11,9 @@ describe('DashboardScreen', () => {
       room: 't35tt',
       players: [
         { token: 'top-hat', balance: 1290 },
-        { token: 'automobile', balance: 1300 }
+        { token: 'automobile', balance: 1300 },
+        { token: 'thimble', balance: 0, bankrupt: true },
+        { token: 'battleship' }
       ],
       properties: [
         { id: 'oriental-avenue', owner: 'top-hat' },
@@ -64,16 +66,35 @@ describe('DashboardScreen', () => {
       .assert.property('kentucky-avenue').color(colors.red);
   });
 
+  it('shows a bankrupt notice when the player is bankrupt', async function() {
+    await this.grm.mock({
+      room: 't35tt',
+      players: [
+        { token: 'top-hat', bankrupt: true }
+      ]
+    });
+
+    await dashboard
+      .assert.summary.bankrupt()
+      .percySnapshot('bankrupt player');
+  });
+
   it('shows other players\' summaries', async () => {
     let colors = await dashboard.get('state.config.groupColors');
 
     await dashboard
-      .assert.card().count(1)
+      .assert.card().count(3)
       .assert.card(0).property().count(3)
       .assert.card(0).name('PLAYER 2')
       .assert.card(0).token('automobile')
       .assert.card(0).property('ventnor-avenue').group('yellow')
-      .assert.card(0).property('ventnor-avenue').color(colors.yellow);
+      .assert.card(0).property('ventnor-avenue').color(colors.yellow)
+      .assert.card(1).name('PLAYER 4')
+      .assert.card(1).token('battleship')
+      .assert.card(1).text('NO OWNED PROPERTIES')
+      .assert.card(2).name('PLAYER 3')
+      .assert.card(2).token('thimble')
+      .assert.card(2).text('BANKRUPT');
   });
 
   it('links to other players\' properties', async () => {

--- a/app/test/acceptance/properties.test.js
+++ b/app/test/acceptance/properties.test.js
@@ -398,6 +398,18 @@ describe('PropertiesScreen', () => {
         .percySnapshot('after renting');
     });
 
+    it('does not show a rent button when bankrupt', async function() {
+      await this.grm.mock({
+        room: 't35tt',
+        players: [{ token: 'top-hat', bankrupt: true }]
+      });
+
+      await search
+        .input.type('penn')
+        .assert.property.name('PENNSYLVANIA AVENUE')
+        .assert.property.rentBtn.not.exists();
+    });
+
     describe('renting utilities', () => {
       beforeEach(async () => {
         await search

--- a/app/test/acceptance/transfer-property.test.js
+++ b/app/test/acceptance/transfer-property.test.js
@@ -72,6 +72,17 @@ describe('TransferPropertyScreen', () => {
       .percySnapshot('other player chosen');
   });
 
+  it('disables bankrupt players', async function() {
+    await this.grm.mock({
+      room: 't35tt',
+      players: [{ token: 'thimble', bankrupt: true }]
+    });
+
+    await transfer
+      .assert.recipient('thimble').disabled()
+      .percySnapshot('other player bankrupt');
+  });
+
   it('has a submit button', async () => {
     await transfer
       .assert.submit.exists();

--- a/app/test/acceptance/transfer.test.js
+++ b/app/test/acceptance/transfer.test.js
@@ -222,5 +222,16 @@ describe('TransferScreen', () => {
       await transfer
         .percySnapshot('after paying a player');
     });
+
+    it('disables bankrupt players', async function() {
+      await this.grm.mock({
+        room: 't35tt',
+        players: [{ token: 'automobile', bankrupt: true }]
+      });
+
+      await transfer
+        .assert.recipient.token('automobile').disabled()
+        .percySnapshot('with a bankrupt player');
+    });
   });
 });

--- a/app/test/interactors/bank.js
+++ b/app/test/interactors/bank.js
@@ -1,4 +1,10 @@
-import interactor, { attribute, collection, scoped } from 'interactor.js';
+import interactor, {
+  attribute,
+  collection,
+  disabled,
+  scoped
+} from 'interactor.js';
+
 import GameRoomInteractor from './game-room';
 
 @interactor class BankInteractor extends GameRoomInteractor {
@@ -17,7 +23,9 @@ import GameRoomInteractor from './game-room';
     }),
     players: collection(token => (
       `[data-test-player-select] [data-test-radio-item${token ? `="${token}"` : ''}]`
-    )),
+    ), {
+      disabled: disabled('input[type="radio"]')
+    }),
     submitBtn: scoped('button[type="submit"]')
   });
 }

--- a/app/test/interactors/bank.js
+++ b/app/test/interactors/bank.js
@@ -10,6 +10,16 @@ import GameRoomInteractor from './game-room';
   links = collection('[data-test-card]', {
     icon: attribute('[data-test-text-icon]', 'title')
   });
+
+  bankrupt = scoped('[data-test-modal]', {
+    heading: scoped('[data-test-modal-title]', {
+      icon: attribute('[data-test-text-icon]', 'title')
+    }),
+    players: collection(token => (
+      `[data-test-player-select] [data-test-radio-item${token ? `="${token}"` : ''}]`
+    )),
+    submitBtn: scoped('button[type="submit"]')
+  });
 }
 
 export default BankInteractor;

--- a/app/test/interactors/dashboard.js
+++ b/app/test/interactors/dashboard.js
@@ -3,6 +3,7 @@ import interactor, {
   collection,
   computed,
   count,
+  exists,
   scoped,
   text
 } from 'interactor.js';
@@ -20,7 +21,9 @@ function rgb2hex(color) {
   name = text('[data-test-player-name]');
   token = attribute('[data-test-player-name] [data-test-text-icon]', 'title');
   balance = text('[data-test-player-balance]');
-  groups = count('[data-test-property-list-group]');
+  text = text('[data-test-properties-list]');
+  bankrupt = exists('[data-test-summary-bankrupt]');
+  groups = count('[data-test-properties-list-group]');
   property = collection(id => id ? `[data-test-property="${id}"]` : '[data-test-property]', {
     group: attribute('[data-test-property-swatch]', 'data-test-property-swatch'),
     color: computed('[data-test-property-swatch]', $el => rgb2hex($el.style.backgroundColor))

--- a/app/test/interactors/transfer-property.js
+++ b/app/test/interactors/transfer-property.js
@@ -1,4 +1,12 @@
-import interactor, { check, checked, collection, text, scoped } from 'interactor.js';
+import interactor, {
+  check,
+  checked,
+  collection,
+  disabled,
+  text,
+  scoped
+} from 'interactor.js';
+
 import GameRoomInteractor from './game-room';
 
 @interactor class TransferPropertyInteractor extends GameRoomInteractor {
@@ -14,6 +22,7 @@ import GameRoomInteractor from './game-room';
   ), {
     select: check('input[type="radio"]'),
     selected: checked('input[type="radio"]'),
+    disabled: disabled('input[type="radio"]'),
     name: text('[data-test-player-select-name]')
   });
 

--- a/app/test/interactors/transfer.js
+++ b/app/test/interactors/transfer.js
@@ -3,6 +3,7 @@ import interactor, {
   count,
   collection,
   checked,
+  disabled,
   text,
   scoped
 } from 'interactor.js';
@@ -26,6 +27,7 @@ import GameRoomInteractor from './game-room';
 
     token: collection(token => `[data-test-radio-item="${token}"]`, {
       selected: checked('input[type="radio"]'),
+      disabled: disabled('input[type="radio"]'),
       name: text('[data-test-player-select-name]')
     })
   });


### PR DESCRIPTION
## Purpose

There should be a bankrupt player button on the bank screen which should take you to another screen or show you a modal to choose a beneficiary before confirming bankruptcy. 

Bankrupt players also need to be visible in the dashboard and their player select tokens disabled in relevant forms.

## Approach

Show a bankrupt button on the bank screen. When clicked, show a modal that allows choosing a beneficiary. After claiming bankruptcy, the player is redirected to the dashboard.

### Todos:

- [x] Show the player when they are bankrupt
- [x] Show when other players are bankrupt
- [x] Disable any actions for bankrupt players
- [x] Disable bankrupt players' tokens in player select fields
- [x] Testssss

### Questions:

For future reference:

- Should bankrupt players get polled for veto requests? 
- Should bankrupt players be allowed to veto other players' actions?