### PR TITLE
✨ Scrollable containers

### DIFF
--- a/app/src/screens/bank.js
+++ b/app/src/screens/bank.js
@@ -32,7 +32,10 @@ export default function BankScreen({ push }) {
   }, [bankruptResponse.ok]);
 
   return (
-    <Container data-test-bank>
+    <Container
+      scrollable
+      data-test-bank
+    >
       <NavBar
         title="Bank"
         titleIcon="bank"
@@ -41,7 +44,7 @@ export default function BankScreen({ push }) {
       />
 
       {!isBankrupt && (
-        <Section>
+        <Section flex="none">
           <Card linkTo={`/${room}/transfer`}>
             <Text upper icon="transfer">
               Transfer

--- a/app/src/screens/dashboard.js
+++ b/app/src/screens/dashboard.js
@@ -26,7 +26,10 @@ export default function DashboardScreen() {
   ), [player.token, players.all]);
 
   return (
-    <Container data-test-dashboard>
+    <Container
+      scrollable
+      data-test-dashboard
+    >
       <NavBar
         title={player.name}
         titleIcon={player.token}

--- a/app/src/ui/layout/container.js
+++ b/app/src/ui/layout/container.js
@@ -17,6 +17,7 @@ Container.propTypes = {
     'between',
     'stretch'
   ]),
+  scrollable: PropTypes.bool,
   tagName: PropTypes.string,
   className: PropTypes.string
 };
@@ -25,6 +26,7 @@ export default function Container({
   row,
   align,
   justify,
+  scrollable,
   tagName: Component = 'div',
   className,
   ...props
@@ -34,6 +36,7 @@ export default function Container({
       className={cx('container', {
         [`align-${align}`]: !!align,
         [`justify-${justify}`]: !!justify,
+        'is-scrollable': !!scrollable,
         row: !!row
       }, className)}
       {...props}

--- a/app/src/ui/layout/layout.css
+++ b/app/src/ui/layout/layout.css
@@ -9,6 +9,10 @@
   &.row {
     flex-direction: row;
   }
+
+  &.is-scrollable {
+    overflow-y: auto;
+  }
 }
 
 .section {

--- a/app/src/ui/layout/section.js
+++ b/app/src/ui/layout/section.js
@@ -21,7 +21,8 @@ Section.propTypes = {
     'start',
     'between',
     'stretch'
-  ])
+  ]),
+  className: PropTypes.string
 };
 
 export default function Section({
@@ -30,6 +31,7 @@ export default function Section({
   align,
   justify,
   collapse,
+  className,
   ...props
 }) {
   return (
@@ -39,7 +41,7 @@ export default function Section({
         [`justify-${justify}`]: !!justify,
         'is-collapsed': collapse,
         row
-      })}
+      }, className)}
       style={!!flex ? { flex } : null}
       {...props}
     />

--- a/app/src/ui/modal/modal.css
+++ b/app/src/ui/modal/modal.css
@@ -3,18 +3,20 @@
 .modal {
   background: var(--color-bg);
   border-radius: var(--radius-xl);
-  position: absolute;
+  position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   box-shadow: var(--shadow-lg);
   width: 22rem;
   min-height: 14rem;
+  z-index: 9999;
 }
 
 .modal-backdrop {
-  position: absolute;
+  position: fixed;
   width: 100%;
   height: 100%;
   background: color-mod(black a(80%));
+  z-index: 9998;
 }

--- a/app/src/ui/nav-bar/nav-bar.css
+++ b/app/src/ui/nav-bar/nav-bar.css
@@ -1,6 +1,16 @@
 @import '../../styles/variables';
 
 .root {
+  z-index: 999;
+  position: sticky;
+  background: linear-gradient(
+    to bottom,
+    var(--color-bg) 20%,
+    color-mod(var(--color-bg) a(0))
+  );
+}
+
+.section {
   height: var(--pad-xl);
   display: flex;
   flex-direction: row;
@@ -9,13 +19,13 @@
 }
 
 .left {
-  @extend .root;
+  @extend .section;
   align-self: flex-start;
   justify-content: flex-start;
 }
 
 .right {
-  @extend .root;
+  @extend .section;
   align-self: flex-end;
   justify-content: flex-end;
 }

--- a/app/src/ui/nav-bar/nav-bar.js
+++ b/app/src/ui/nav-bar/nav-bar.js
@@ -35,8 +35,8 @@ export default function NavBar({
   let { location, goBack } = useRouter();
 
   return (
-    <Section flex="none" row>
-      <div className={styles['left']}>
+    <Section row flex="none" className={styles.root}>
+      <div className={styles.left}>
         {renderLeft ? renderLeft() : (showBack && location.state?.internal ? (
           <Button style="icon" onClick={goBack} data-test-back>
             <Icon name="larr"/>
@@ -59,7 +59,7 @@ export default function NavBar({
         </Text>
       )}
 
-      <div className={styles['right']}>
+      <div className={styles.right}>
         {renderRight ? renderRight() : (!!roomCode && (
           <Text sm upper color="secondary" data-test-room-code>
             {roomCode}


### PR DESCRIPTION
## Purpose

Containers need to be scrollable in certain situations, such as when there are more than 3-4 players or when viewing game history.

## Approach

Add a `scrollable` property to container components that should be scrollable.

Modals are made to be fixed and the nav-bar is made to be sticky on scroll.