### PR TITLE
✨ Viewable game history

### DIFF
--- a/app/src/game/game-history.js
+++ b/app/src/game/game-history.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { useOwnNameFormatter } from '../helpers/hooks';
+
+import Section from '../ui/layout/section';
+import Text from '../ui/typography/text';
+
+import Toast from '../ui/toaster/toast';
+
+GameHistory.propTypes = {
+  player: PropTypes.shape({
+    token: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  }),
+  history: PropTypes.arrayOf(PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    meta: PropTypes.shape({
+      player: PropTypes.string
+    })
+  })).isRequired
+};
+
+export default function GameHistory({
+  player,
+  history
+}) {
+  let format = useOwnNameFormatter();
+
+  return history.length ? (
+    <Section data-test-game-history>
+      <Text center upper sm>
+        History
+      </Text>
+
+      <Section>
+        {history.map(({ message, meta }, i) => (
+          <Toast
+            key={i}
+            type={meta?.player === player.token ? 'message' : 'default'}
+            message={format(message)}
+          />
+        ))}
+      </Section>
+    </Section>
+  ) : null;
+}

--- a/app/src/helpers/hooks.js
+++ b/app/src/helpers/hooks.js
@@ -75,3 +75,10 @@ function useFilteredProperties(filterFn, deps) {
     ), []) ?? []
   ), [filter, properties]);
 }
+
+export function useOwnNameFormatter() {
+  let { player: { name } } = useGame();
+  let reg = useMemo(() => new RegExp(`(^|\\s+)${name}(\\s+|$)`), [name]);
+  let formatter = useCallback(m => m.replace(reg, '$1YOU$2'));
+  return formatter;
+}

--- a/app/src/screens/bank.js
+++ b/app/src/screens/bank.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { useGame, useEmit } from '../api';
@@ -11,17 +11,22 @@ import Card from '../ui/card';
 import Modal from '../ui/modal';
 
 import BankruptForm from '../game/bankrupt-form';
+import GameHistory from '../game/game-history';
 
 BankScreen.propTypes = {
   push: PropTypes.func.isRequired
 };
 
 export default function BankScreen({ push }) {
-  let { room, player } = useGame();
+  let { room, player, notice, history } = useGame();
   let players = usePlayers({ exclude: [player.token] });
   let { bankrupt: isBankrupt } = usePlayer(player.token);
   let [ showBankruptForm, toggleBankruptForm ] = useState(false);
   let [ bankrupt, bankruptResponse ] = useEmit('player:bankrupt');
+
+  let notices = useMemo(() => (
+    [notice].concat(history.map(({ notice }) => notice)).filter(Boolean)
+  ), [notice, history]);
 
   let handleBankrupt = useCallback(beneficiary => {
     if (!bankruptResponse.pending) bankrupt(beneficiary.token);
@@ -64,6 +69,11 @@ export default function BankScreen({ push }) {
           </Card>
         </Section>
       )}
+
+      <GameHistory
+        player={player}
+        history={notices}
+      />
 
       {showBankruptForm && (
         <Modal

--- a/app/src/ui/toaster/toaster.css
+++ b/app/src/ui/toaster/toaster.css
@@ -6,10 +6,6 @@
   top: auto;
   bottom: 0;
   width: 100%;
-
-  .toast {
-    margin-bottom: var(--pad-med);
-  }
 }
 
 .toast {
@@ -21,6 +17,7 @@
   line-height: var(--pad-med);
   padding: calc(var(--pad-lg) / 2);
   color: var(--color-primary);
+  margin-bottom: var(--pad-med);
 
   &.is-alert {
     color: var(--color-alert);

--- a/app/src/ui/toaster/toaster.js
+++ b/app/src/ui/toaster/toaster.js
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import styles from './toaster.css';
 
 import { useEmit, useGame, useEmitter } from '../../api';
+import { useOwnNameFormatter } from '../../helpers/hooks';
 import Toast from './toast';
 
 function toastReducer(state, action) {
@@ -21,18 +22,11 @@ function toastReducer(state, action) {
 }
 
 export default function Toaster() {
+  let game = useGame();
+  let emitter = useEmitter();
   let [ toasts, updateToasts ] = useReducer(toastReducer, []);
   let [ vote, voted ] = useEmit('poll:vote');
-  let emitter = useEmitter();
-  let game = useGame();
-
-  let nameReg = useMemo(() => (
-    new RegExp(`(^|\\s+)${game.player.name}(\\s+|$)`)
-  ), [game.player.name]);
-
-  let formatMessage = useCallback(message => (
-    message.replace(nameReg, '$1YOU$2')
-  ), [nameReg]);
+  let format = useOwnNameFormatter();
 
   useEffect(() => {
     let last = 0;
@@ -105,7 +99,7 @@ export default function Toaster() {
             <Toast
               key={id}
               type={type}
-              message={formatMessage(message)}
+              message={format(message)}
               actions={[
                 { label: 'Yes', action: () => vote(id, true) },
                 { label: 'No', action: () => vote(id, false) }
@@ -117,7 +111,7 @@ export default function Toaster() {
             <Toast
               key={id}
               type={type}
-              message={formatMessage(message)}
+              message={format(message)}
               dismiss={() => updateToasts({ remove: id })}
               timeout={5 * 1000}
             />

--- a/app/test/acceptance/bank.test.js
+++ b/app/test/acceptance/bank.test.js
@@ -74,6 +74,27 @@ describe('BankScreen', () => {
       .assert.icon('currency');
   });
 
+  it('shows game history', async function() {
+    await this.grm.mock({
+      room: 't35tt',
+      notice: { message: 'PLAYER 1 purchased Vermont Avenue', token: 'top-hat' },
+      history: [
+        { notice: { message: 'PLAYER 2 joined the game', token: 'top-hat' } },
+        { notice: { message: 'PLAYER 1 received 200', token: 'top-hat' } }
+      ]
+    });
+
+    await bank
+      .assert.exists()
+      .assert.gameHistory.toasts(0).message('YOU purchased Vermont Avenue')
+      .assert.gameHistory.toasts().count(3)
+      .percySnapshot('with history');
+  });
+
+  it('does not show game history when there is none', async () => {
+    await bank.assert.gameHistory.not.exists();
+  });
+
   it('shows a bankruptcy modal after clicking the bankrupt button', async () => {
     await bank
       .links(2).click()

--- a/app/test/acceptance/properties.test.js
+++ b/app/test/acceptance/properties.test.js
@@ -439,7 +439,8 @@ describe('PropertiesScreen', () => {
           .assert.value('2')
           .rollBtn.click()
           .assert.not.value('2');
-      });
+      // sometimes it rolls a 2, what are the chances it'll happen twice?
+      }).retries(2);
 
       it('disables the submit button when the roll is outside of the range', async () => {
         await search.utilForm.only()

--- a/app/test/interactors/bank.js
+++ b/app/test/interactors/bank.js
@@ -5,7 +5,9 @@ import interactor, {
   scoped
 } from 'interactor.js';
 
-import GameRoomInteractor from './game-room';
+import GameRoomInteractor, {
+  ToastInteractor
+} from './game-room';
 
 @interactor class BankInteractor extends GameRoomInteractor {
   static defaultScope = '[data-test-bank]';
@@ -15,6 +17,10 @@ import GameRoomInteractor from './game-room';
   backBtn = scoped('[data-test-back]');
   links = collection('[data-test-card]', {
     icon: attribute('[data-test-text-icon]', 'title')
+  });
+
+  gameHistory = scoped('[data-test-game-history]', {
+    toasts: collection('[data-test-toast]', ToastInteractor)
   });
 
   bankrupt = scoped('[data-test-modal]', {

--- a/app/test/interactors/game-room.js
+++ b/app/test/interactors/game-room.js
@@ -48,3 +48,4 @@ import AppInteractor from './app';
 }
 
 export default GameRoomInteractor;
+export { ToastInteractor };

--- a/server/src/history.js
+++ b/server/src/history.js
@@ -41,7 +41,12 @@ function merge(a, b) {
 // adds a new diff to the history of the next state
 export function recordHistory(prev, next) {
   let state = { ...next, timestamp: Date.now() };
-  state.history = [diff(prev, state), ...(state.history || [])];
+  let change = diff(prev, state);
+
+  if (change) {
+    state.history = [change, ...(state.history || [])];
+  }
+
   return state;
 }
 

--- a/server/src/player.js
+++ b/server/src/player.js
@@ -70,7 +70,14 @@ export default class Player {
 
         // respond to the event with the error name and message
         let { id, name, message } = error;
-        this.send('response:error', event, { id, name, message });
+        let payload = { id, name, message };
+
+        // useful for debugging
+        if (process.env.NODE_ENV !== 'production' && !(error instanceof MonopolyError)) {
+          payload.stack = error.stack;
+        }
+
+        this.send('response:error', event, payload);
       }
     }
   }

--- a/server/src/state/create.js
+++ b/server/src/state/create.js
@@ -18,6 +18,7 @@ export default function create({
     players: { all: [] },
     timestamp: Date.now(),
     notice: null,
+    history: [],
 
     properties: properties.reduce((map, property) => {
       let id = slug(property.name, { lower: true });

--- a/server/test/helpers/mock-server.js
+++ b/server/test/helpers/mock-server.js
@@ -12,7 +12,9 @@ export async function mockGame({
   properties = [],
   bank,
   houses,
-  hotels
+  hotels,
+  notice,
+  history = []
 } = {}) {
   let state;
 
@@ -40,6 +42,8 @@ export async function mockGame({
     bank: bank ?? state.bank,
     houses: houses ?? state.houses,
     hotels: hotels ?? state.hotels,
+    notice: notice ?? state.notice,
+    history: state.history.concat(history),
     timestamp: Date.now(),
 
     // automatically create players with a starting balance and name

--- a/server/test/helpers/mock-server.js
+++ b/server/test/helpers/mock-server.js
@@ -107,8 +107,10 @@ async function createTestSocket(socket, initevents = []) {
 
   let send = emitter.send;
   emitter.send = (...args) => {
-    return send(...args).catch(({ message }) => {
-      throw new Error(message);
+    return send(...args).catch((err) => {
+      let e = new Error(err.message);
+      e.stack = err.stack;
+      throw e;
     });
   };
 


### PR DESCRIPTION
## Purpose

Makes game history viewable from the bank screen! This moves closer to being able to veto actions from the UI.

---

I found these files changed and uncommitted (along with #50). After sorting through the files and creating commits for them, it appears that this does the same thing as #46; so these changes are likely just as old (6-7 months old). Since these PRs are the same and that one has requested changes this one takes into account, I'll merge this one and close the "older" one.

## Approach

Thanks to #50 making containers scrollable, this allows a scrollable list of notifications viewable from the bank screen. The formatting logic from the Toaster component was moved into a hook so it can be utilized by the new GameHistory component. Toast margins were also adjusted to fit into the new view.

There were some other changes I found that were causing test failures, although I wasn't sure what caused the failures at first. I made the player socket emit stack traces on errors and the mock-server error handler use the new, proper, stack trace. The offending changes were promptly found, removed, and the rest of the changes seem to work without them.